### PR TITLE
Add Eldev, Buttercup test suite and GitHub Actions CI

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,8 @@
+((nil
+  (bug-reference-url-format . "https://github.com/erlang/emacs-erlang-ts/issues/%s")
+  (indent-tabs-mode . nil)
+  (fill-column . 80)
+  (checkdoc-arguments-in-order-flag))
+ (emacs-lisp-mode
+  (bug-reference-bug-regexp . "#\\(?2:[[:digit:]]+\\)")
+  (package-lint-main-file . "erlang-ts.el")))

--- a/.elpaignore
+++ b/.elpaignore
@@ -1,0 +1,4 @@
+test/
+Eldev
+.eldev/
+.github/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs-version:
+          - 29.4
+          - 30.1
+          - snapshot
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs-version }}
+
+      - uses: emacs-eldev/setup-eldev@v1
+
+      - name: Install tree-sitter grammar
+        run: |
+          emacs --batch --eval "
+          (progn
+            (require 'treesit)
+            (add-to-list 'treesit-language-source-alist
+                         '(erlang \"https://github.com/WhatsApp/tree-sitter-erlang\"))
+            (treesit-install-language-grammar 'erlang))"
+
+      - run: eldev byte-compile --warnings-as-errors
+
+      - run: eldev test
+
+      - run: eldev lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.eldev
+*-autoloads.el
+*.elc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to erlang-ts
+
+If you discover issues, have ideas for improvements or new features,
+please report them to the [issue tracker][1] of the repository or
+submit a pull request. Please, try to follow these guidelines when you
+do so.
+
+## Issue reporting
+
+* Check that the issue has not already been reported.
+* Check that the issue has not already been fixed in the latest code
+  (a.k.a. `main`).
+* Be clear, concise and precise in your description of the problem.
+* Open an issue with a descriptive title and a summary in grammatically correct,
+  complete sentences.
+* Mention your Emacs version and operating system.
+* Include any relevant code to the issue summary.
+
+## Pull requests
+
+* Use a topic branch to easily amend a pull request later, if necessary.
+* Write [good commit messages][2].
+* Mention related tickets in the commit messages (e.g. `[Fix #N] Fix font-lock for ...`).
+* Use the same coding conventions as the rest of the project.
+* Verify your Emacs Lisp code with `checkdoc` (`C-c ? d`).
+* [Squash related commits together][3].
+* Open a [pull request][4] that relates to *only* one subject with a clear title
+  and description in grammatically correct, complete sentences.
+
+## Getting started
+
+The project uses [Eldev][5] for building, testing, and linting. Make sure
+you have it installed before proceeding.
+
+### Installing Eldev
+
+The simplest way to install Eldev:
+
+```
+curl -fsSL https://raw.github.com/emacs-eldev/eldev/master/webinstall/eldev | sh
+```
+
+See the [Eldev documentation][5] for alternative installation methods.
+
+### Installing the tree-sitter grammar
+
+erlang-ts requires the Erlang tree-sitter grammar. Install it from
+within Emacs:
+
+```
+M-x treesit-install-language-grammar
+Language: erlang
+URL: https://github.com/WhatsApp/tree-sitter-erlang
+```
+
+Or add the grammar source to your config so it's always available:
+
+```emacs-lisp
+(add-to-list 'treesit-language-source-alist
+             '(erlang "https://github.com/WhatsApp/tree-sitter-erlang"))
+```
+
+### Running the tests
+
+The test suite uses [Buttercup][6]. Run it with:
+
+```
+eldev test
+```
+
+### Byte-compiling
+
+```
+eldev byte-compile
+```
+
+To treat warnings as errors (as CI does):
+
+```
+eldev byte-compile --warnings-as-errors
+```
+
+### Linting
+
+```
+eldev lint
+```
+
+This runs `checkdoc` and `package-lint` checks.
+
+### All checks at once
+
+To run the same checks CI runs:
+
+```
+eldev byte-compile --warnings-as-errors && eldev test && eldev lint
+```
+
+## Debugging
+
+Use `M-x treesit-explore-mode` to inspect the tree-sitter syntax tree
+and find the right node types for font-lock rules.
+
+## Project layout
+
+```
+erlang-ts.el          Main package file
+test/
+  erlang-ts-font-lock-test.el      Font-lock tests (Buttercup)
+  erlang-ts-indentation-test.el    Indentation tests (Buttercup)
+  resources/
+    sample.erl                     Sample Erlang file for testing
+Eldev                 Build configuration
+.github/
+  workflows/
+    ci.yml            GitHub Actions CI
+```
+
+[1]: https://github.com/erlang/emacs-erlang-ts/issues
+[2]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[3]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
+[4]: https://help.github.com/articles/using-pull-requests
+[5]: https://github.com/emacs-eldev/eldev
+[6]: https://github.com/jorgenschaefer/emacs-buttercup

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,34 @@
+; -*- mode: emacs-lisp; lexical-binding: t -*-
+
+(eldev-require-version "1.11")
+
+(eldev-use-package-archive 'gnu-elpa)
+(eldev-use-package-archive 'nongnu-elpa)
+(eldev-use-package-archive 'melpa)
+
+;; Snap-installed Emacs may need these environment variables when
+;; invoked in batch mode (e.g. via Eldev).
+(when (and (file-directory-p "/snap/emacs/current/")
+           (not (getenv "EMACS_SNAP_DIR")))
+  (setenv "EMACS_SNAP_DIR" "/snap/emacs/current/")
+  (setenv "EMACS_SNAP_USER_COMMON"
+          (expand-file-name "snap/emacs/common" "~/")))
+
+(eldev-use-plugin 'autoloads)
+
+(eldev-add-extra-dependencies 'test 'buttercup)
+
+;; Install the Erlang tree-sitter grammar if not already available.
+(require 'treesit)
+(add-to-list 'treesit-language-source-alist
+             '(erlang "https://github.com/WhatsApp/tree-sitter-erlang"))
+(unless (treesit-language-available-p 'erlang)
+  (treesit-install-language-grammar 'erlang))
+
+;; configuration for the default linters
+(setq byte-compile-docstring-max-column 120)
+(setq checkdoc-force-docstrings-flag nil)
+(setq checkdoc-permit-comma-termination-flag t)
+(setq checkdoc--interactive-docstring-flag nil)
+
+(setq eldev-project-main-file "erlang-ts.el")

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Install/compile erlang treesitter support (first time or update treesitter gramm
 Customize `treesit-font-lock-level` variable to increase/decrease the coloring,
 or use `M-x erlang-font-lock-level-1-4` to change it.
 
+# Hacking #
 
-
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to run tests,
+and guidelines for submitting changes.
 

--- a/test/erlang-ts-font-lock-test.el
+++ b/test/erlang-ts-font-lock-test.el
@@ -1,0 +1,392 @@
+;;; erlang-ts-font-lock-test.el --- Font-lock tests for erlang-ts -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Bozhidar Batsov
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+
+;; Buttercup tests for erlang-ts-mode font-lock rules.
+;; Tests are organized by font-lock feature, matching the 4 levels
+;; defined in `treesit-font-lock-feature-list'.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'erlang-ts)
+
+;;;; Test helpers
+
+(defmacro with-fontified-erlang-ts-buffer (content &rest body)
+  "Set up a temporary buffer with CONTENT, apply erlang-ts-mode font-lock, run BODY.
+All four font-lock levels are activated so every feature is testable."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (insert ,content)
+     (let ((treesit-font-lock-level 4))
+       (erlang-ts-mode))
+     (font-lock-ensure)
+     (goto-char (point-min))
+     ,@body))
+
+(defun erlang-ts-test-face-at (start end)
+  "Return the face at range [START, END] in the current buffer.
+If all positions in the range share the same face, return it.
+Otherwise return the symbol `various-faces'."
+  (let ((face (get-text-property start 'face)))
+    (if (= start end)
+        face
+      (let ((pos (1+ start))
+            (consistent t))
+        (while (and consistent (<= pos end))
+          (unless (equal (get-text-property pos 'face) face)
+            (setq consistent nil))
+          (setq pos (1+ pos)))
+        (if consistent face 'various-faces)))))
+
+(defun erlang-ts-test-expect-faces-at (content &rest face-specs)
+  "Fontify CONTENT with `erlang-ts-mode' and assert FACE-SPECS.
+Each element of FACE-SPECS is a list (START END EXPECTED-FACE)
+where START and END are buffer positions (1-indexed, inclusive)."
+  (with-fontified-erlang-ts-buffer content
+    (dolist (spec face-specs)
+      (let* ((start (nth 0 spec))
+             (end (nth 1 spec))
+             (expected (nth 2 spec))
+             (actual (erlang-ts-test-face-at start end)))
+        (expect actual :to-equal expected)))))
+
+(defmacro when-fontifying-it (description &rest tests)
+  "Create a Buttercup test asserting font-lock faces in Erlang code.
+DESCRIPTION is the test name.  Each element of TESTS is
+  (CODE (START END FACE) ...)
+where CODE is an Erlang source string and each (START END FACE)
+triple asserts that positions START through END have FACE."
+  (declare (indent 1))
+  `(it ,description
+     (dolist (test (quote ,tests))
+       (apply #'erlang-ts-test-expect-faces-at test))))
+
+;;;; Tests
+
+(describe "erlang-ts font-lock"
+  (before-all
+    (unless (treesit-language-available-p 'erlang)
+      (signal 'buttercup-pending "tree-sitter Erlang grammar not available")))
+
+  ;; ---- Level 1 features ------------------------------------------------
+
+  (describe "comment feature"
+    (when-fontifying-it "fontifies line comments"
+      ;; % a comment
+      ;; 12345678901
+      ("% a comment"
+       (1 11 font-lock-comment-face)))
+
+    (when-fontifying-it "fontifies double-percent comments"
+      ;; %% a comment
+      ;; 123456789012
+      ("%% a comment"
+       (1 12 font-lock-comment-face))))
+
+  (describe "string feature"
+    (when-fontifying-it "fontifies string literals"
+      ;; "hello"
+      ;; 1234567
+      ("\"hello\""
+       (1 7 font-lock-string-face))))
+
+  (describe "keyword feature"
+    (when-fontifying-it "fontifies case/of/end"
+      ;; case X of\n  _ -> ok\nend
+      ;; 1234
+      ("case X of\n  _ -> ok\nend"
+       (1 4 font-lock-keyword-face)))
+
+    (when-fontifying-it "fontifies if/end"
+      ;; if\n  true -> ok\nend
+      ;; 12
+      ("if\n  true -> ok\nend"
+       (1 2 font-lock-keyword-face)))
+
+    (when-fontifying-it "fontifies try/catch/end"
+      ;; try\n  ok\ncatch\n  _:_ -> error\nend
+      ;; 123
+      ("try\n  ok\ncatch\n  _:_ -> error\nend"
+       (1 3 font-lock-keyword-face)))
+
+    (when-fontifying-it "fontifies receive"
+      ;; receive\n  _ -> ok\nend
+      ;; 1234567
+      ("receive\n  _ -> ok\nend"
+       (1 7 font-lock-keyword-face)))
+
+    (when-fontifying-it "fontifies fun keyword"
+      ;; fun(X) -> X end
+      ;; 123
+      ("fun(X) -> X end"
+       (1 3 font-lock-keyword-face)))
+
+    (when-fontifying-it "fontifies begin/end"
+      ;; begin ok end
+      ;; 12345
+      ("begin ok end"
+       (1 5 font-lock-keyword-face)))
+
+    (when-fontifying-it "fontifies maybe/else"
+      ;; maybe\n  ok\nelse\n  error\nend
+      ;; 12345
+      ("maybe\n  ok\nelse\n  error\nend"
+       (1 5 font-lock-keyword-face)))
+
+    (when-fontifying-it "fontifies when"
+      ;; f(X) when X > 0 -> X.
+      ;; 123456789012345
+      ;; "when" starts at 6
+      ("f(X) when X > 0 -> X."
+       (6 9 font-lock-keyword-face))))
+
+  (describe "doc feature"
+    (when-fontifying-it "fontifies -doc string"
+      ;; -doc "A doc string".
+      ;; 12345678901234567890
+      ("-doc \"A doc string\"."
+       (6 19 font-lock-doc-face))))
+
+  ;; ---- Level 2 features ------------------------------------------------
+
+  (describe "preprocessor feature"
+    (when-fontifying-it "fontifies -module attribute"
+      ;; -module(foo).
+      ;; 12345678
+      ("-module(foo)."
+       (1 7 font-lock-preprocessor-face)))
+
+    (when-fontifying-it "fontifies -export attribute"
+      ;; -export([foo/1]).
+      ;; 1234567
+      ("-export([foo/1])."
+       (1 7 font-lock-preprocessor-face)))
+
+    (when-fontifying-it "fontifies -define"
+      ;; -define(MAX, 100).
+      ;; 1234567
+      ("-define(MAX, 100)."
+       (1 7 font-lock-preprocessor-face)))
+
+    (when-fontifying-it "fontifies -record"
+      ;; -record(foo, {bar}).
+      ;; 1234567
+      ("-record(foo, {bar})."
+       (1 7 font-lock-preprocessor-face)))
+
+    (when-fontifying-it "fontifies -spec"
+      ;; -spec foo(integer()) -> ok.
+      ;; 12345
+      ("-spec foo(integer()) -> ok."
+       (1 5 font-lock-preprocessor-face)))
+
+    (when-fontifying-it "fontifies -type"
+      ;; -type color() :: red | green.
+      ;; 12345
+      ("-type color() :: red | green."
+       (1 5 font-lock-preprocessor-face)))
+
+    (when-fontifying-it "fontifies -callback"
+      ;; -callback init(Args) -> ok.
+      ;; 123456789
+      ("-callback init(Args) -> ok."
+       (1 9 font-lock-preprocessor-face)))
+
+    (when-fontifying-it "fontifies -ifdef"
+      ;; -ifdef(TEST).
+      ;; 123456
+      ("-ifdef(TEST)."
+       (1 6 font-lock-preprocessor-face)))
+
+    (when-fontifying-it "fontifies macro calls"
+      ;; ?MAX_SIZE
+      ;;  23456789
+      ("?MAX_SIZE"
+       (2 9 font-lock-preprocessor-face))))
+
+  (describe "definition feature"
+    (when-fontifying-it "fontifies function names"
+      ;; hello(Name) ->
+      ;; 12345
+      ("hello(Name) ->\n    ok."
+       (1 5 font-lock-function-name-face)))
+
+    (when-fontifying-it "fontifies function names in -spec"
+      ;; -spec hello(string()) -> ok.
+      ;; 1234567890
+      ("-spec hello(string()) -> ok."
+       (7 11 font-lock-function-name-face)))
+
+    (when-fontifying-it "fontifies function names in -callback"
+      ;; -callback init(term()) -> ok.
+      ;; 12345678901234
+      ("-callback init(term()) -> ok."
+       (11 14 font-lock-function-name-face))))
+
+  (describe "type feature"
+    (when-fontifying-it "fontifies type names in -type"
+      ;; -type color() :: red.
+      ;; 123456789012
+      ("-type color() :: red."
+       (7 11 font-lock-type-face)))
+
+    (when-fontifying-it "fontifies record names"
+      ;; -record(person, {name}).
+      ;; 12345678901234
+      ("-record(person, {name})."
+       (9 14 font-lock-type-face)))
+
+    (when-fontifying-it "fontifies record field names in declarations"
+      ;; -record(person, {name}).
+      ;; 123456789012345678901
+      ("-record(person, {name})."
+       (18 21 font-lock-property-name-face))))
+
+  ;; ---- Level 3 features ------------------------------------------------
+
+  (describe "variable feature"
+    (when-fontifying-it "fontifies variables"
+      ;; foo(Name) ->
+      ;; 12345678
+      ("foo(Name) ->\n    Name."
+       (5 8 font-lock-variable-name-face))))
+
+  (describe "constant feature"
+    (when-fontifying-it "fontifies quoted atoms"
+      ;; 'hello world'
+      ;; 1234567890123
+      ("'hello world'"
+       (1 13 font-lock-constant-face)))
+
+    (when-fontifying-it "fontifies char literals"
+      ;; $A
+      ;; 12
+      ("$A"
+       (1 2 font-lock-constant-face))))
+
+  (describe "function-call feature"
+    (when-fontifying-it "fontifies function calls"
+      ;; foo(X) ->\n    bar(X).
+      ;; position 15-17 = bar
+      ("foo(X) ->\n    bar(X)."
+       (15 17 font-lock-function-call-face))))
+
+  ;; ---- Level 4 features ------------------------------------------------
+
+  (describe "operator feature"
+    (when-fontifying-it "fontifies -> operator"
+      ;; foo() -> ok.
+      ;; 1234567
+      ("foo() -> ok."
+       (7 8 font-lock-operator-face)))
+
+    (when-fontifying-it "fontifies arithmetic operators"
+      ;; X + Y
+      ;; 12345
+      ("X + Y"
+       (3 3 font-lock-operator-face)))
+
+    (when-fontifying-it "fontifies comparison operators"
+      ;; X >= Y
+      ;; 123456
+      ("X >= Y"
+       (3 4 font-lock-operator-face)))
+
+    (when-fontifying-it "fontifies list operators"
+      ;; X ++ Y
+      ;; 123456
+      ("X ++ Y"
+       (3 4 font-lock-operator-face))))
+
+  (describe "bracket feature"
+    (when-fontifying-it "fontifies parentheses"
+      ;; f(X)
+      ;; 1234
+      ("f(X)"
+       (2 2 font-lock-bracket-face)
+       (4 4 font-lock-bracket-face)))
+
+    (when-fontifying-it "fontifies square brackets"
+      ;; [1, 2]
+      ;; 123456
+      ("[1, 2]"
+       (1 1 font-lock-bracket-face)
+       (6 6 font-lock-bracket-face)))
+
+    (when-fontifying-it "fontifies curly braces"
+      ;; {ok, 1}
+      ;; 1234567
+      ("{ok, 1}"
+       (1 1 font-lock-bracket-face)
+       (7 7 font-lock-bracket-face)))
+
+    (when-fontifying-it "fontifies binary delimiters"
+      ;; <<1, 2>>
+      ;; 12345678
+      ("<<1, 2>>"
+       (1 2 font-lock-bracket-face)
+       (7 8 font-lock-bracket-face))))
+
+  (describe "delimiter feature"
+    (when-fontifying-it "fontifies dots"
+      ;; foo() -> ok.
+      ;; 123456789012
+      ("foo() -> ok."
+       (12 12 font-lock-delimiter-face)))
+
+    (when-fontifying-it "fontifies commas"
+      ;; {1, 2}
+      ;; 123456
+      ("{1, 2}"
+       (3 3 font-lock-delimiter-face)))
+
+    (when-fontifying-it "fontifies semicolons"
+      ;; case X of\n  a -> 1;\n  b -> 2\nend
+      ;; the ; is at position 19
+      ("case X of\n  a -> 1;\n  b -> 2\nend"
+       (19 19 font-lock-delimiter-face)))
+
+    (when-fontifying-it "fontifies pipes in lists"
+      ;; [H | T]
+      ;; 1234567
+      ("[H | T]"
+       (4 4 font-lock-delimiter-face))))
+
+  (describe "number feature"
+    (when-fontifying-it "fontifies integers"
+      ;; 42
+      ;; 12
+      ("42"
+       (1 2 font-lock-number-face)))
+
+    (when-fontifying-it "fontifies floats"
+      ;; 3.14
+      ;; 1234
+      ("3.14"
+       (1 4 font-lock-number-face)))
+
+    (when-fontifying-it "fontifies base-N integers"
+      ;; 16#FF
+      ;; 12345
+      ("16#FF"
+       (1 5 font-lock-number-face))))
+
+  (describe "remote-module feature"
+    (when-fontifying-it "fontifies module in remote call"
+      ;; io:format("~p~n", [X])
+      ;; 12
+      ("io:format(\"~p~n\", [X])"
+       (1 2 font-lock-constant-face)))
+
+    (when-fontifying-it "fontifies function in remote call"
+      ;; io:format("~p~n", [X])
+      ;; 1234567890
+      ("io:format(\"~p~n\", [X])"
+       (4 9 font-lock-function-name-face)))))
+
+;;; erlang-ts-font-lock-test.el ends here

--- a/test/erlang-ts-indentation-test.el
+++ b/test/erlang-ts-indentation-test.el
@@ -1,0 +1,147 @@
+;;; erlang-ts-indentation-test.el --- Indentation tests for erlang-ts -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Bozhidar Batsov
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+
+;; Buttercup tests for erlang-ts-mode indentation.
+;; Since erlang-ts-mode derives from erlang-mode, it inherits
+;; erlang-mode's indentation engine.  These tests verify that
+;; indentation works correctly under erlang-ts-mode.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'erlang-ts)
+
+(defun erlang-ts-test--strip-indentation (code)
+  "Remove all leading whitespace from each line of CODE."
+  (mapconcat
+   (lambda (line) (string-trim-left line))
+   (split-string code "\n")
+   "\n"))
+
+(defmacro when-indenting-it (description &rest code-strings)
+  "Create a Buttercup test that asserts each CODE-STRING indents correctly.
+DESCRIPTION is the test name.  Each element of CODE-STRINGS is a
+properly-indented Erlang code string.  The macro strips indentation,
+re-indents via `erlang-ts-mode', and asserts the result matches the original."
+  (declare (indent 1))
+  `(it ,description
+     ,@(mapcar
+        (lambda (code)
+          `(let ((expected ,code))
+             (expect
+              (with-temp-buffer
+                (insert (erlang-ts-test--strip-indentation expected))
+                (erlang-ts-mode)
+                (setq-local indent-tabs-mode nil)
+                (indent-region (point-min) (point-max))
+                (buffer-string))
+              :to-equal expected)))
+        code-strings)))
+
+(describe "erlang-ts indentation"
+  (before-all
+    (unless (treesit-language-available-p 'erlang)
+      (signal 'buttercup-pending "tree-sitter Erlang grammar not available")))
+
+  (when-indenting-it "indents a simple function"
+    "hello(Name) ->
+    io:format(\"Hello, ~s!~n\", [Name]).")
+
+  (when-indenting-it "indents a function with multiple clauses"
+    "factorial(0) -> 1;
+factorial(N) when N > 0 ->
+    N * factorial(N - 1).")
+
+  (when-indenting-it "indents a case expression"
+    "process(Type) ->
+    case Type of
+        parse ->
+            ok;
+        validate ->
+            error
+    end.")
+
+  (when-indenting-it "indents an if expression"
+    "check(X) ->
+    if
+        X > 0 ->
+            positive;
+        X < 0 ->
+            negative;
+        true ->
+            zero
+    end.")
+
+  (when-indenting-it "indents try/catch"
+    "safe_call(F) ->
+    try
+        F()
+    catch
+        error:Reason ->
+            {error, Reason}
+    end.")
+
+  (when-indenting-it "indents a receive expression"
+    "loop() ->
+    receive
+        {msg, Msg} ->
+            handle(Msg),
+            loop();
+        stop ->
+            ok
+    end.")
+
+  (when-indenting-it "indents a receive with after"
+    "wait() ->
+    receive
+        Msg ->
+            Msg
+    after 5000 ->
+            timeout
+    end.")
+
+  (when-indenting-it "indents a fun expression"
+    "make_adder(N) ->
+    fun(X) ->
+            N + X
+    end.")
+
+  (when-indenting-it "indents a list comprehension"
+    "doubles(Xs) ->
+    [X * 2 || X <- Xs].")
+
+  (when-indenting-it "indents a record definition"
+    "-record(person, {
+                 name :: string(),
+                 age :: non_neg_integer()
+                }).")
+
+  (when-indenting-it "indents a type definition"
+    "-type color() :: red | green | blue.")
+
+  (when-indenting-it "indents begin/end"
+    "run() ->
+    begin
+        step1(),
+        step2()
+    end.")
+
+  (when-indenting-it "indents nested case expressions"
+    "nested(X, Y) ->
+    case X of
+        a ->
+            case Y of
+                b ->
+                    ok;
+                _ ->
+                    error
+            end;
+        _ ->
+            skip
+    end."))
+
+;;; erlang-ts-indentation-test.el ends here

--- a/test/resources/sample.erl
+++ b/test/resources/sample.erl
@@ -1,0 +1,75 @@
+%% Copyright (C) 2026 Bozhidar Batsov
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(sample).
+
+-export([hello/1, factorial/1, process/2]).
+
+-include("sample.hrl").
+
+-define(MAX_SIZE, 100).
+-define(DOUBLE(X), (X * 2)).
+
+-type color() :: red | green | blue.
+-type result(T) :: {ok, T} | {error, term()}.
+
+-record(person, {
+    name :: string(),
+    age :: non_neg_integer()
+}).
+
+-spec hello(string()) -> ok.
+hello(Name) ->
+    io:format("Hello, ~s!~n", [Name]).
+
+-spec factorial(non_neg_integer()) -> pos_integer().
+factorial(0) -> 1;
+factorial(N) when N > 0 ->
+    N * factorial(N - 1).
+
+process(Type, Data) ->
+    case Type of
+        parse ->
+            parse_data(Data);
+        validate ->
+            validate_data(Data);
+        _ ->
+            {error, unknown_type}
+    end.
+
+parse_data(Data) ->
+    try
+        {ok, do_parse(Data)}
+    catch
+        error:Reason ->
+            {error, Reason}
+    end.
+
+validate_data(Data) ->
+    if
+        is_list(Data) ->
+            {ok, Data};
+        is_binary(Data) ->
+            {ok, binary_to_list(Data)};
+        true ->
+            {error, invalid}
+    end.
+
+do_parse(Data) ->
+    [X || X <- Data, X > 0].
+
+start_loop() ->
+    receive
+        {msg, Msg} ->
+            io:format("Got: ~p~n", [Msg]),
+            start_loop();
+        stop ->
+            ok
+    after 5000 ->
+        timeout
+    end.
+
+-ifdef(TEST).
+run_tests() ->
+    ok.
+-endif.


### PR DESCRIPTION
I've been meaning to contribute more to this mode for a while now, and after getting my own [neocaml](https://github.com/bbatsov/neocaml) project to a good state I decided to apply some of the learnings here.

In particular, I think it's very important to set up some decent test infrastructure before moving forward with the rest of the font-locking and indentation improvements that I have in mind. Having a solid test suite makes it much easier to iterate on changes with confidence.

This adds [Eldev](https://github.com/emacs-eldev/eldev) as the build tool with [Buttercup](https://github.com/jorgenschaefer/emacs-buttercup) for testing. The test suite covers font-lock rules across all 4 treesit levels and basic indentation for common Erlang constructs. There's also a GitHub Actions CI workflow that runs byte-compilation (warnings-as-errors), the tests, and linting against Emacs 29.4, 30.1, and snapshot.

I also added a `CONTRIBUTING.md` with development setup instructions, `.dir-locals.el`, `.gitignore`, and `.elpaignore` for general project hygiene.