### PR TITLE
Add mode menu and grammar installation command

### DIFF
--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -67,6 +67,26 @@
 (require 'treesit)
 (require 'erlang)
 
+;;; Grammar installation
+
+(defconst erlang-ts-grammar-recipe
+  '(erlang "https://github.com/WhatsApp/tree-sitter-erlang")
+  "Tree-sitter grammar recipe for Erlang.
+A list of (LANGUAGE URL) suitable for use in
+`treesit-language-source-alist'.")
+
+;;;###autoload
+(defun erlang-ts-install-grammar (&optional force)
+  "Install the Erlang tree-sitter grammar if not already available.
+With prefix argument FORCE, reinstall even if already installed.
+This is useful after upgrading to a version that requires a newer
+grammar."
+  (interactive "P")
+  (when (or force (not (treesit-language-available-p 'erlang nil)))
+    (message "Installing Erlang tree-sitter grammar...")
+    (let ((treesit-language-source-alist (list erlang-ts-grammar-recipe)))
+      (treesit-install-language-grammar 'erlang))))
+
 ;; Override erlang font-lock functions
 ;; So the menus (and functions) work as expected
 (defun erlang-ts--font-lock-level-1 (func &rest args)

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -556,6 +556,9 @@ Use (setq lsp-enable-imenu nil) to disable lsp-imenu"
   "Major mode for editing erlang with tree-sitter."
   :syntax-table nil
   (erlang-ts-syntax-table-init)
+  (unless (treesit-language-available-p 'erlang)
+    (when (y-or-n-p "Erlang tree-sitter grammar is not installed.  Install it now?")
+      (erlang-ts-install-grammar)))
   (when (treesit-ready-p 'erlang)
     (treesit-parser-create 'erlang)
     (erlang-ts-setup)))

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -529,6 +529,28 @@ Use (setq lsp-enable-imenu nil) to disable lsp-imenu"
   (advice-remove #'erlang-font-lock-level-4 #'erlang-ts--font-lock-level-4))
 
 
+;;; Keymap and menu
+
+(defvar erlang-ts-mode-map
+  (let ((map (make-sparse-keymap)))
+    (easy-menu-define erlang-ts-mode-menu map "Erlang-TS Mode Menu"
+      '("Erlang-TS"
+        ("Navigate"
+         ["Beginning of Function" beginning-of-defun]
+         ["End of Function" end-of-defun])
+        "--"
+        ["Mark Function" mark-defun]
+        "--"
+        ("Font-lock level"
+         ["Level 1 (minimal)" erlang-font-lock-level-1]
+         ["Level 2 (keywords)" erlang-font-lock-level-2]
+         ["Level 3 (default)" erlang-font-lock-level-3]
+         ["Level 4 (all)" erlang-font-lock-level-4])
+        "--"
+        ["Install tree-sitter grammar" erlang-ts-install-grammar]))
+    map)
+  "Keymap for `erlang-ts-mode'.")
+
 ;;;###autoload
 (define-derived-mode erlang-ts-mode erlang-mode "erl-ts"
   "Major mode for editing erlang with tree-sitter."


### PR DESCRIPTION
Another small improvement inspired by my work on [neocaml](https://github.com/bbatsov/neocaml) to make it easier for end users to set up erlang-ts.

This adds an `erlang-ts-install-grammar` command so users no longer need to manually configure `treesit-language-source-alist` — they can just do `M-x erlang-ts-install-grammar`. The mode also offers to install the grammar automatically when it detects it's missing.

There's also a basic "Erlang-TS" mode menu with navigation commands, font-lock level switching and a grammar install entry. I plan to populate the menu with more useful commands once #9 gets merged.