### PR TITLE
Add tree-sitter based indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 Requires emacs-29 compiled with treesitter support.
 
-Currently uses treesitter only for syntax-highlighting, *font-lock-mode*, and uses the old
-erlang-mode for everything else.
+Uses tree-sitter for syntax highlighting and indentation. Other features
+(compilation, REPL, etc.) are inherited from erlang-mode.
 
-There is a lot of work to do to convert the old erlang mode to use treesitter, but
+There is a lot of work to do to convert the old erlang mode to use tree-sitter, but
 by re-using the old one we can do the conversion little by little.
 
 Help is appreciated.
@@ -34,6 +34,15 @@ Install/compile erlang treesitter support (first time or update treesitter gramm
 
 Customize `treesit-font-lock-level` variable to increase/decrease the coloring,
 or use `M-x erlang-font-lock-level-1-4` to change it.
+
+## Indentation ##
+
+By default, `erlang-ts-mode` uses tree-sitter based indentation. It respects
+the standard `erlang-indent-level` (default 4) and `erlang-indent-guard` (default 2)
+variables.
+
+To switch back to the classic erlang-mode indentation engine, use
+`M-x erlang-ts-toggle-indent-function` or set `erlang-ts-use-treesit-indent` to `nil`.
 
 ## Markdown in doc attributes ##
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,88 @@ variables.
 To switch back to the classic erlang-mode indentation engine, use
 `M-x erlang-ts-toggle-indent-function` or set `erlang-ts-use-treesit-indent` to `nil`.
 
+### Known indentation limitations ###
+
+The tree-sitter indentation handles common Erlang constructs well but has
+some known gaps compared to erlang-mode. Improvements are ongoing and
+contributions are welcome!
+
+#### Continuation lines ####
+
+Multi-line expressions where a line continues an expression from the
+previous line may not align correctly in all cases:
+
+```erlang
+%% Comprehension generators may misalign:
+Var = [X ||
+                  #record{a=X} <- lists:seq(1, 10),  %% expected
+                  true = (X rem 2)]
+
+%% Multi-line call arguments inside try/catch:
+try
+    io:format("~s ~s~n",
+                      [St0#leex.xfile]),  %% expected
+    parse_rules(Xfile, Line2, Macs, St2)
+catch ...
+```
+
+#### Inline if clauses ####
+
+When `if` has clauses on the same line, subsequent clauses use a slightly
+different alignment than erlang-mode:
+
+```erlang
+%% erlang-mode aligns subsequent clauses at column 3 after `if':
+    if Z >= 0 ->
+            ok;
+       Z =< 10 ->     %% column 7
+            err
+    end
+
+%% tree-sitter aligns at erlang-indent-level:
+    if Z >= 0 ->
+            ok;
+        Z =< 10 ->    %% column 8
+            err
+    end
+```
+
+#### Comma-first / pipe-first style ####
+
+Code using comma-first or pipe-first formatting may not indent as expected:
+
+```erlang
+%% erlang-mode:
+[ a
+, b
+, c
+]
+
+%% tree-sitter:
+[ a
+  , b
+  , c
+]
+```
+
+#### Records with `{` on a separate line ####
+
+When the opening brace is on a different line from `-record(name,`:
+
+```erlang
+%% erlang-mode:
+-record(record0,
+        {           %% aligned after (
+         r0a,
+         r0b
+        }).
+
+%% tree-sitter doesn't handle this multi-line pattern yet
+```
+
+If you encounter indentation issues, you can always switch to erlang-mode's
+indentation with `M-x erlang-ts-toggle-indent-function`.
+
 ## Markdown in doc attributes ##
 
 `erlang-ts-mode` can highlight markdown syntax (bold, italic, code spans, links)

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ or use `M-x erlang-font-lock-level-1-4` to change it.
 
 ## Indentation ##
 
-By default, `erlang-ts-mode` uses tree-sitter based indentation. It respects
-the standard `erlang-indent-level` (default 4) and `erlang-indent-guard` (default 2)
-variables.
+By default, `erlang-ts-mode` uses erlang-mode's classic indentation engine.
+An experimental tree-sitter based indentation engine is also available.
+Both respect the standard `erlang-indent-level` (default 4) and
+`erlang-indent-guard` (default 2) variables.
 
-To switch back to the classic erlang-mode indentation engine, use
-`M-x erlang-ts-toggle-indent-function` or set `erlang-ts-use-treesit-indent` to `nil`.
+To try the tree-sitter indentation, use `M-x erlang-ts-toggle-indent-function`
+or set `erlang-ts-use-treesit-indent` to `t`.
 
 ### Known indentation limitations ###
 

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -524,6 +524,29 @@ position after it.  Used to align elements with the first element."
     (when (re-search-forward "[[({]" (treesit-node-end parent) t)
       (point))))
 
+(defun erlang-ts--anchor-args (_node parent _bol &rest _)
+  "Return anchor position for function arguments in PARENT.
+When the opening `(' has content on the same line, align after it.
+When `(' is at end of line (Okeefe style), indent from parent start."
+  (save-excursion
+    (goto-char (treesit-node-start parent))
+    (when (re-search-forward "(" (treesit-node-end parent) t)
+      (if (looking-at "[ \t]*$")
+          ;; Paren at end of line: use erlang-argument-indent from parent
+          (let ((target-col (+ (save-excursion
+                                 (goto-char (treesit-node-start
+                                             (treesit-node-parent parent)))
+                                 (current-column))
+                               (if (boundp 'erlang-argument-indent)
+                                   erlang-argument-indent
+                                 erlang-indent-level))))
+            (goto-char (treesit-node-start parent))
+            (beginning-of-line)
+            (move-to-column target-col t)
+            (point))
+        ;; Content follows: align after (
+        (point)))))
+
 (defun erlang-ts--anchor-after-open-brace (_node parent _bol &rest _)
   "Return position right after the opening `{' in PARENT.
 Used for record and map fields where `{' is the relevant delimiter."
@@ -617,8 +640,9 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ((parent-is "record_expr") erlang-ts--anchor-after-open-brace 0)
      ((parent-is "map_expr") erlang-ts--anchor-after-open-brace 0)
 
-     ;; Function arguments and collections: align after opening delimiter
-     ((parent-is "expr_args") erlang-ts--anchor-after-open-delim 0)
+     ;; Function arguments: smart alignment (Okeefe-aware)
+     ((parent-is "expr_args") erlang-ts--anchor-args 0)
+     ;; Collections: align after opening delimiter
      ((parent-is "list") erlang-ts--anchor-after-open-delim 0)
      ((parent-is "tuple") erlang-ts--anchor-after-open-delim 0)
      ((parent-is "binary") erlang-ts--anchor-after-open-delim 0)

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -551,6 +551,20 @@ Used for export/import attributes where `[' is the relevant delimiter."
          (equal (treesit-node-type (treesit-node-parent parent))
                 grandparent-type))))
 
+(defun erlang-ts--match-inline-clause-body (clause-type block-type)
+  "Return a matcher for clause_body children in inline-style clauses.
+Matches when the parent is a clause_body inside CLAUSE-TYPE, and the
+clause starts on the same line as the enclosing BLOCK-TYPE keyword."
+  (lambda (_node parent _bol &rest _)
+    (and (equal (treesit-node-type parent) "clause_body")
+         (let ((clause (treesit-node-parent parent)))
+           (and (equal (treesit-node-type clause) clause-type)
+                (let ((block (treesit-node-parent clause)))
+                  (and (equal (treesit-node-type block) block-type)
+                       ;; Check if clause starts on same line as block keyword
+                       (= (line-number-at-pos (treesit-node-start block))
+                          (line-number-at-pos (treesit-node-start clause))))))))))
+
 (defun erlang-ts--indent-rules ()
   "Return tree-sitter indentation rules for Erlang.
 The return value is suitable for `treesit-simple-indent-rules'."
@@ -575,6 +589,10 @@ The return value is suitable for `treesit-simple-indent-rules'."
      (,(erlang-ts--match-clause-body-in "fun_clause")
       erlang-ts--grand-parent-bol erlang-ts--double-indent-offset)
      (,(erlang-ts--match-clause-body-in "receive_after")
+      erlang-ts--grand-parent-bol erlang-ts--double-indent-offset)
+     ;; if_clause body needs 2x indent only when the clause is on
+     ;; the same line as the `if' keyword (inline style)
+     (,(erlang-ts--match-inline-clause-body "if_clause" "if_expr")
       erlang-ts--grand-parent-bol erlang-ts--double-indent-offset)
 
      ;; Expressions inside clause_body: indent from the clause line

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -670,9 +670,10 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ;; Guard
      ((parent-is "guard") parent-bol erlang-indent-guard)
 
-     ;; Type specs
+     ;; Type specs: body indented 2x, | alternatives aligned at indent+2
      ((parent-is "spec") parent-bol erlang-indent-level)
-     ((parent-is "type_alias") parent-bol erlang-indent-level)
+     ((parent-is "type_alias") parent-bol erlang-ts--double-indent-offset)
+     ((parent-is "opaque") parent-bol erlang-ts--double-indent-offset)
      ((parent-is "type_sig") parent-bol erlang-indent-level)
 
      ;; Error recovery

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -670,9 +670,9 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ;; Function arguments: smart alignment (Okeefe-aware)
      ((parent-is "expr_args") erlang-ts--anchor-args 0)
      ;; Collections: align after opening delimiter
-     ((parent-is "list") erlang-ts--anchor-after-open-delim 0)
-     ((parent-is "tuple") erlang-ts--anchor-after-open-delim 0)
-     ((parent-is "binary") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "^list$") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "^tuple$") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "^binary$") erlang-ts--anchor-after-open-delim 0)
 
      ;; Export/import attributes: align after [
      ((parent-is "export_attribute") erlang-ts--anchor-after-open-bracket 0)

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -619,6 +619,10 @@ The return value is suitable for `treesit-simple-indent-rules'."
      (erlang-ts--match-triple-comment column-0 0)
      (erlang-ts--match-single-comment column-0 erlang-ts--offset-comment-column)
 
+     ;; Strings: never re-indent content inside strings
+     ;; (changing indentation would change the string value)
+     ((parent-is "^string$") no-indent 0)
+
      ;; Top-level: column 0
      ((parent-is "source_file") column-0 0)
 

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -490,9 +490,11 @@ Returns `markdown-inline' when inside a doc attribute string,
 
 ;;; Indentation
 
-(defcustom erlang-ts-use-treesit-indent t
+(defcustom erlang-ts-use-treesit-indent nil
   "When non-nil, use tree-sitter based indentation.
-When nil, use the classic erlang-mode indentation engine."
+When nil, use the classic erlang-mode indentation engine.
+The tree-sitter indentation is experimental and may not handle
+all cases correctly, especially incomplete code during editing."
   :type 'boolean
   :group 'erlang)
 

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -609,6 +609,9 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ((parent-is "block_expr") parent-bol erlang-indent-level)
      ((parent-is "maybe_expr") parent-bol erlang-indent-level)
 
+     ;; Macro body: align after opening (
+     ((parent-is "pp_define") erlang-ts--anchor-after-open-delim 0)
+
      ;; Record/map fields: align after { (not ( which comes earlier)
      ((node-is "record_field") erlang-ts--anchor-after-open-brace 0)
      ((parent-is "record_expr") erlang-ts--anchor-after-open-brace 0)

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -502,15 +502,31 @@ When nil, use the classic erlang-mode indentation engine."
       (back-to-indentation)
       (point))))
 
-(defun erlang-ts--anchor-open-brace (_node parent _bol &rest _)
-  "Return position of the opening `{' in PARENT."
+(defun erlang-ts--anchor-matching-open (node parent _bol &rest _)
+  "Return position of the opening delimiter matching NODE.
+Matches `)' to `(', `]' to `[', and `}' to `{'."
+  (let ((close (treesit-node-type node)))
+    (save-excursion
+      (goto-char (treesit-node-start parent))
+      (let ((open (pcase close
+                    (")" "(")
+                    ("]" "\\[")
+                    ("}" "{"))))
+        (when (and open (re-search-forward open (treesit-node-end parent) t))
+          (1- (point)))))))
+
+(defun erlang-ts--anchor-after-open-delim (_node parent _bol &rest _)
+  "Return position right after the opening delimiter in PARENT.
+Finds the first `(', `[', or `{' in PARENT and returns the
+position after it.  Used to align elements with the first element."
   (save-excursion
     (goto-char (treesit-node-start parent))
-    (when (search-forward "{" (treesit-node-end parent) t)
-      (1- (point)))))
+    (when (re-search-forward "[[({]" (treesit-node-end parent) t)
+      (point))))
 
 (defun erlang-ts--anchor-after-open-brace (_node parent _bol &rest _)
-  "Return position right after the opening `{' in PARENT."
+  "Return position right after the opening `{' in PARENT.
+Used for record and map fields where `{' is the relevant delimiter."
   (save-excursion
     (goto-char (treesit-node-start parent))
     (when (search-forward "{" (treesit-node-end parent) t)
@@ -543,10 +559,8 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ;; receive_after aligns with receive
      ((node-is "receive_after") parent-bol 0)
 
-     ;; Closing braces in records/maps: align with opening {
-     ((match "^}$" "record_decl") erlang-ts--anchor-open-brace 0)
-     ((match "^}$" "record_expr") erlang-ts--anchor-open-brace 0)
-     ((match "^}$" "map_expr") erlang-ts--anchor-open-brace 0)
+     ;; Closing delimiters: align with their opening counterpart
+     ((match "^[])}]$" nil) erlang-ts--anchor-matching-open 0)
 
      ;; clause_body inside fun_clause/receive_after needs 2x indent
      ;; because the clause starts on the same line as the keyword
@@ -569,18 +583,21 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ((parent-is "block_expr") parent-bol erlang-indent-level)
      ((parent-is "maybe_expr") parent-bol erlang-indent-level)
 
-     ;; Record fields: align after {
+     ;; Record/map fields: align after { (not ( which comes earlier)
      ((node-is "record_field") erlang-ts--anchor-after-open-brace 0)
      ((parent-is "record_expr") erlang-ts--anchor-after-open-brace 0)
-
-     ;; Map fields: align after {
      ((parent-is "map_expr") erlang-ts--anchor-after-open-brace 0)
 
-     ;; Function arguments, collections
-     ((parent-is "expr_args") parent-bol erlang-indent-level)
-     ((parent-is "list") parent-bol erlang-indent-level)
-     ((parent-is "tuple") parent-bol erlang-indent-level)
-     ((parent-is "binary") parent-bol erlang-indent-level)
+     ;; Function arguments and collections: align after opening delimiter
+     ((parent-is "expr_args") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "list") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "tuple") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "binary") erlang-ts--anchor-after-open-delim 0)
+
+     ;; Export/import attributes: align after [
+     ((parent-is "export_attribute") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "import_attribute") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "export_type_attribute") erlang-ts--anchor-after-open-delim 0)
 
      ;; Comprehensions
      ((parent-is "list_comprehension") parent-bol erlang-indent-level)

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -503,7 +503,7 @@ When nil, use the classic erlang-mode indentation engine."
       (point))))
 
 (defun erlang-ts--anchor-matching-open (node parent _bol &rest _)
-  "Return position of the opening delimiter matching NODE.
+  "Return position of the opening delimiter matching NODE in PARENT.
 Matches `)' to `(', `]' to `[', and `}' to `{'."
   (let ((close (treesit-node-type node)))
     (save-excursion
@@ -564,13 +564,13 @@ Used for export/import attributes where `[' is the relevant delimiter."
       (point))))
 
 (defun erlang-ts--match-triple-comment (node _parent _bol &rest _)
-  "Match %%% comments (three or more percent signs)."
+  "Match NODE when it is a %%% comment (three or more percent signs)."
   (and node
        (equal (treesit-node-type node) "comment")
        (string-prefix-p "%%%" (treesit-node-text node))))
 
 (defun erlang-ts--match-single-comment (node _parent _bol &rest _)
-  "Match single % comments (not %% or %%%)."
+  "Match NODE when it is a single % comment (not %% or %%%)."
   (and node
        (equal (treesit-node-type node) "comment")
        (let ((text (treesit-node-text node)))

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -481,10 +481,12 @@ Computed lazily on first use.")
   "Return the tree-sitter language at POS.
 Returns `markdown-inline' when inside a doc attribute string,
 `erlang' otherwise."
-  (let ((node (treesit-node-at pos 'markdown-inline)))
-    (if (and node (not (equal (treesit-node-type node) "document")))
-        'markdown-inline
-      'erlang)))
+  (if (and (seq-some (lambda (p) (eq (treesit-parser-language p) 'markdown-inline))
+                     (treesit-parser-list))
+           (let ((node (treesit-node-at pos 'markdown-inline)))
+             (and node (not (equal (treesit-node-type node) "document")))))
+      'markdown-inline
+    'erlang))
 
 ;;; Indentation
 

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -532,6 +532,14 @@ Used for record and map fields where `{' is the relevant delimiter."
     (when (search-forward "{" (treesit-node-end parent) t)
       (point))))
 
+(defun erlang-ts--anchor-after-open-bracket (_node parent _bol &rest _)
+  "Return position right after the opening `[' in PARENT.
+Used for export/import attributes where `[' is the relevant delimiter."
+  (save-excursion
+    (goto-char (treesit-node-start parent))
+    (when (search-forward "[" (treesit-node-end parent) t)
+      (point))))
+
 (defun erlang-ts--double-indent-offset (_node _parent _bol &rest _)
   "Return double `erlang-indent-level'."
   (* 2 erlang-indent-level))
@@ -595,9 +603,9 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ((parent-is "binary") erlang-ts--anchor-after-open-delim 0)
 
      ;; Export/import attributes: align after [
-     ((parent-is "export_attribute") erlang-ts--anchor-after-open-delim 0)
-     ((parent-is "import_attribute") erlang-ts--anchor-after-open-delim 0)
-     ((parent-is "export_type_attribute") erlang-ts--anchor-after-open-delim 0)
+     ((parent-is "export_attribute") erlang-ts--anchor-after-open-bracket 0)
+     ((parent-is "import_attribute") erlang-ts--anchor-after-open-bracket 0)
+     ((parent-is "export_type_attribute") erlang-ts--anchor-after-open-bracket 0)
 
      ;; Comprehensions
      ((parent-is "list_comprehension") parent-bol erlang-indent-level)

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -563,6 +563,24 @@ Used for export/import attributes where `[' is the relevant delimiter."
     (when (search-forward "[" (treesit-node-end parent) t)
       (point))))
 
+(defun erlang-ts--match-triple-comment (node _parent _bol &rest _)
+  "Match %%% comments (three or more percent signs)."
+  (and node
+       (equal (treesit-node-type node) "comment")
+       (string-prefix-p "%%%" (treesit-node-text node))))
+
+(defun erlang-ts--match-single-comment (node _parent _bol &rest _)
+  "Match single % comments (not %% or %%%)."
+  (and node
+       (equal (treesit-node-type node) "comment")
+       (let ((text (treesit-node-text node)))
+         (and (string-prefix-p "%" text)
+              (not (string-prefix-p "%%" text))))))
+
+(defun erlang-ts--offset-comment-column (_node _parent _bol &rest _)
+  "Return `comment-column' as an absolute offset for single-% comments."
+  (or comment-column 48))
+
 (defun erlang-ts--double-indent-offset (_node _parent _bol &rest _)
   "Return double `erlang-indent-level'."
   (* 2 erlang-indent-level))
@@ -592,6 +610,13 @@ clause starts on the same line as the enclosing BLOCK-TYPE keyword."
   "Return tree-sitter indentation rules for Erlang.
 The return value is suitable for `treesit-simple-indent-rules'."
   `((erlang
+     ;; Erlang comment conventions:
+     ;; %%% always at column 0
+     ;; %% context-dependent (follows code indentation)
+     ;; % right-aligned to comment-column
+     (erlang-ts--match-triple-comment column-0 0)
+     (erlang-ts--match-single-comment column-0 erlang-ts--offset-comment-column)
+
      ;; Top-level: column 0
      ((parent-is "source_file") column-0 0)
 

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -631,6 +631,17 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ;; Comprehensions
      ((parent-is "list_comprehension") parent-bol erlang-indent-level)
      ((parent-is "binary_comprehension") parent-bol erlang-indent-level)
+     ((parent-is "lc_exprs") parent-bol 0)
+     ((parent-is "lc_or_zc_expr") parent-bol 0)
+     ((parent-is "generator") parent-bol erlang-indent-level)
+     ((parent-is "b_generator") parent-bol erlang-indent-level)
+
+     ;; Multi-line expressions
+     ((parent-is "binary_op_expr") parent-bol erlang-indent-level)
+     ((parent-is "match_expr") parent-bol erlang-indent-level)
+     ((parent-is "unary_op_expr") parent-bol erlang-indent-level)
+     ((parent-is "pipe") parent-bol 0)
+     ((parent-is "paren_expr") parent-bol erlang-indent-level)
 
      ;; Guard
      ((parent-is "guard") parent-bol erlang-indent-guard)

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -31,8 +31,8 @@
 ;;
 ;; Requires emacs-29 compiled with treesitter support.
 ;;
-;; Currently uses treesitter only for syntax-highlighting,
-;; *font-lock-mode*, and uses the "old" erlang-mode for everything else.
+;; Uses tree-sitter for syntax-highlighting and indentation.
+;; Other features are inherited from erlang-mode.
 ;;
 ;; # Install #
 ;;
@@ -57,7 +57,7 @@
 
 ;; Introduction:
 ;; ------------
-;; Currently handles font-locking for erlang-mode
+;; Handles font-locking and indentation for erlang-mode using tree-sitter.
 ;;
 ;; Devs See:
 ;;    M-x treesit-explore-mode
@@ -160,7 +160,8 @@ FUNC with ARGS will be called if `erlang-ts-mode' is not active."
     "when")
   "Erlang reserved keywords.")
 
-(defvar erlang-ts-font-lock-rules
+(defun erlang-ts--build-font-lock-rules ()
+  "Build tree-sitter font-lock rules for Erlang."
   (treesit-font-lock-rules
    :language 'erlang
    :feature 'doc
@@ -317,11 +318,12 @@ FUNC with ARGS will be called if `erlang-ts-mode' is not active."
    '(([ "->" "||" "<-" "<=" "+" "-" "*" "/" "++"
         ">" ">=" "<" "=<" "=" "==" "=:=" "=/="
         "<:-" "<:=" "&&"])
-     @font-lock-operator-face))
+     @font-lock-operator-face)))
 
+(defvar erlang-ts-font-lock-rules nil
   "Tree-sitter font-lock settings for `erlang-ts-mode'.
-Use `treesit-font-lock-level' or `treesit-font-lock-feature-list'
- to change settings")
+Computed lazily on first use.  Use `treesit-font-lock-level' or
+`treesit-font-lock-feature-list' to change settings.")
 
 (defun erlang-ts-in-type-context-p (node)
   "Check if NODE is within a type definition context."
@@ -345,14 +347,23 @@ Use `treesit-font-lock-level' or `treesit-font-lock-feature-list'
         t
       nil)))
 
-(defvar erlang-ts--syntax-propertize-query
-  (when (treesit-available-p)
-    (treesit-query-compile
-     'erlang
-     '(((char) @node-char)
-       ((atom) @node-atom)
-       ((string) @node-string-triple-quoted (:match "^\"\"\"" @node-string-triple-quoted))
-       ((string) @node-string)))))
+(defvar erlang-ts--syntax-propertize-query nil
+  "Compiled tree-sitter query for `syntax-propertize'.
+Computed lazily on first use.")
+
+(defun erlang-ts--build-syntax-propertize-query ()
+  "Build and cache the `syntax-propertize' query."
+  (unless erlang-ts--syntax-propertize-query
+    (when (treesit-language-available-p 'erlang)
+      (setq erlang-ts--syntax-propertize-query
+            (treesit-query-compile
+             'erlang
+             '(((char) @node-char)
+               ((atom) @node-atom)
+               ((string) @node-string-triple-quoted
+                         (:match "^\"\"\"" @node-string-triple-quoted))
+               ((string) @node-string))))))
+  erlang-ts--syntax-propertize-query)
 
 (defun erlang-ts--process-node (node)
   "Process a single or double quoted string or atom node.
@@ -404,7 +415,7 @@ NODE is the treesit node to process."
 (defun erlang-ts--syntax-propertize (start end)
   "Apply syntax properties for Erlang specific patterns from START to END."
   (let ((captures
-         (treesit-query-capture 'erlang erlang-ts--syntax-propertize-query start end)))
+         (treesit-query-capture 'erlang (erlang-ts--build-syntax-propertize-query) start end)))
     (pcase-dolist (`(,name . ,node) captures)
       (pcase name
         ('node-char   (erlang-ts--process-node-char node))
@@ -475,6 +486,132 @@ Returns `markdown-inline' when inside a doc attribute string,
         'markdown-inline
       'erlang)))
 
+;;; Indentation
+
+(defcustom erlang-ts-use-treesit-indent t
+  "When non-nil, use tree-sitter based indentation.
+When nil, use the classic erlang-mode indentation engine."
+  :type 'boolean
+  :group 'erlang)
+
+(defun erlang-ts--grand-parent-bol (_node parent _bol &rest _)
+  "Return the first non-whitespace position on PARENT's parent's line."
+  (when-let* ((gp (treesit-node-parent parent)))
+    (save-excursion
+      (goto-char (treesit-node-start gp))
+      (back-to-indentation)
+      (point))))
+
+(defun erlang-ts--anchor-open-brace (_node parent _bol &rest _)
+  "Return position of the opening `{' in PARENT."
+  (save-excursion
+    (goto-char (treesit-node-start parent))
+    (when (search-forward "{" (treesit-node-end parent) t)
+      (1- (point)))))
+
+(defun erlang-ts--anchor-after-open-brace (_node parent _bol &rest _)
+  "Return position right after the opening `{' in PARENT."
+  (save-excursion
+    (goto-char (treesit-node-start parent))
+    (when (search-forward "{" (treesit-node-end parent) t)
+      (point))))
+
+(defun erlang-ts--double-indent-offset (_node _parent _bol &rest _)
+  "Return double `erlang-indent-level'."
+  (* 2 erlang-indent-level))
+
+(defun erlang-ts--match-clause-body-in (grandparent-type)
+  "Return a matcher for clause_body children inside GRANDPARENT-TYPE."
+  (lambda (_node parent _bol &rest _)
+    (and (equal (treesit-node-type parent) "clause_body")
+         (equal (treesit-node-type (treesit-node-parent parent))
+                grandparent-type))))
+
+(defun erlang-ts--indent-rules ()
+  "Return tree-sitter indentation rules for Erlang.
+The return value is suitable for `treesit-simple-indent-rules'."
+  `((erlang
+     ;; Top-level: column 0
+     ((parent-is "source_file") column-0 0)
+
+     ;; `end' aligns with opening construct
+     ((node-is "end") parent-bol 0)
+
+     ;; Keywords that align with their opening construct
+     ((match "^catch$" "try_expr") parent-bol 0)
+
+     ;; receive_after aligns with receive
+     ((node-is "receive_after") parent-bol 0)
+
+     ;; Closing braces in records/maps: align with opening {
+     ((match "^}$" "record_decl") erlang-ts--anchor-open-brace 0)
+     ((match "^}$" "record_expr") erlang-ts--anchor-open-brace 0)
+     ((match "^}$" "map_expr") erlang-ts--anchor-open-brace 0)
+
+     ;; clause_body inside fun_clause/receive_after needs 2x indent
+     ;; because the clause starts on the same line as the keyword
+     (,(erlang-ts--match-clause-body-in "fun_clause")
+      erlang-ts--grand-parent-bol erlang-ts--double-indent-offset)
+     (,(erlang-ts--match-clause-body-in "receive_after")
+      erlang-ts--grand-parent-bol erlang-ts--double-indent-offset)
+
+     ;; Expressions inside clause_body: indent from the clause line
+     ((parent-is "clause_body") parent-bol erlang-indent-level)
+
+     ;; Clauses inside block constructs
+     ((parent-is "case_expr") parent-bol erlang-indent-level)
+     ((parent-is "receive_expr") parent-bol erlang-indent-level)
+     ((parent-is "if_expr") parent-bol erlang-indent-level)
+     ((parent-is "try_expr") parent-bol erlang-indent-level)
+     ((parent-is "catch_clause") parent-bol erlang-indent-level)
+     ((parent-is "receive_after") parent-bol erlang-indent-level)
+     ((parent-is "anonymous_fun") parent-bol erlang-indent-level)
+     ((parent-is "block_expr") parent-bol erlang-indent-level)
+     ((parent-is "maybe_expr") parent-bol erlang-indent-level)
+
+     ;; Record fields: align after {
+     ((node-is "record_field") erlang-ts--anchor-after-open-brace 0)
+     ((parent-is "record_expr") erlang-ts--anchor-after-open-brace 0)
+
+     ;; Map fields: align after {
+     ((parent-is "map_expr") erlang-ts--anchor-after-open-brace 0)
+
+     ;; Function arguments, collections
+     ((parent-is "expr_args") parent-bol erlang-indent-level)
+     ((parent-is "list") parent-bol erlang-indent-level)
+     ((parent-is "tuple") parent-bol erlang-indent-level)
+     ((parent-is "binary") parent-bol erlang-indent-level)
+
+     ;; Comprehensions
+     ((parent-is "list_comprehension") parent-bol erlang-indent-level)
+     ((parent-is "binary_comprehension") parent-bol erlang-indent-level)
+
+     ;; Guard
+     ((parent-is "guard") parent-bol erlang-indent-guard)
+
+     ;; Type specs
+     ((parent-is "spec") parent-bol erlang-indent-level)
+     ((parent-is "type_alias") parent-bol erlang-indent-level)
+     ((parent-is "type_sig") parent-bol erlang-indent-level)
+
+     ;; Error recovery
+     ((parent-is "ERROR") parent-bol erlang-indent-level)
+
+     ;; Catch-all: preserve previous line indentation
+     (no-node prev-line 0))))
+
+(defun erlang-ts-toggle-indent-function ()
+  "Toggle between tree-sitter and erlang-mode indentation."
+  (interactive)
+  (if (eq indent-line-function 'treesit-indent)
+      (progn
+        (setq-local indent-line-function #'erlang-indent-command)
+        (setq-local indent-region-function #'erlang-indent-region)
+        (message "Switched to erlang-mode indentation"))
+    (setq-local indent-line-function #'treesit-indent)
+    (setq-local indent-region-function #'treesit-indent-region)
+    (message "Switched to tree-sitter indentation")))
+
 ;;  imenu support
 
 (defun erlang-ts-imenu-node-func-p (node)
@@ -523,6 +660,11 @@ Use (setq lsp-enable-imenu nil) to disable lsp-imenu"
 
 (defun erlang-ts-setup ()
   "Setup treesit for erlang."
+
+  ;; Compute font-lock rules lazily if not done at load time
+  ;; (e.g. grammar wasn't available during byte-compilation)
+  (unless erlang-ts-font-lock-rules
+    (setq erlang-ts-font-lock-rules (erlang-ts--build-font-lock-rules)))
 
   (let ((use-markdown (and erlang-ts-use-markdown-inline
                            (>= emacs-major-version 30)
@@ -577,7 +719,10 @@ Use (setq lsp-enable-imenu nil) to disable lsp-imenu"
       (face-remap-add-relative 'font-lock-property-name-face
                                :inherit font-lock-constant-face))
 
-  ;; (setq-local treesit-simple-indent-rules erlang-ts-indent-rules)
+  (setq-local treesit-simple-indent-rules (erlang-ts--indent-rules))
+  (when erlang-ts-use-treesit-indent
+    (setq-local indent-line-function #'treesit-indent)
+    (setq-local indent-region-function #'treesit-indent-region))
 
   (if (boundp 'lsp-language-id-configuration)
       (add-to-list 'lsp-language-id-configuration
@@ -631,6 +776,7 @@ Use (setq lsp-enable-imenu nil) to disable lsp-imenu"
          ["Level 3 (default)" erlang-font-lock-level-3]
          ["Level 4 (all)" erlang-font-lock-level-4])
         "--"
+        ["Toggle tree-sitter indentation" erlang-ts-toggle-indent-function]
         ["Install tree-sitter grammar" erlang-ts-install-grammar]
         ["Install markdown grammar" erlang-ts-install-markdown-grammar]))
     map)

--- a/test/erlang-ts-indentation-test.el
+++ b/test/erlang-ts-indentation-test.el
@@ -159,4 +159,81 @@ factorial(N) when N > 0 ->
             skip
     end."))
 
+;;;; File-based indentation tests (from OTP emacs_SUITE_data)
+
+(defvar erlang-ts-test--resource-dir
+  (expand-file-name "resources/emacs_SUITE_data/"
+                    (file-name-directory
+                     (or load-file-name buffer-file-name)))
+  "Directory containing OTP indentation test files.")
+
+(defun erlang-ts-test--indent-file (file indent-fn region-fn)
+  "Read FILE, strip indentation, re-indent, and return the result.
+Uses INDENT-FN and REGION-FN for indentation."
+  (let ((expected (with-temp-buffer
+                    (insert-file-contents file)
+                    (buffer-string))))
+    (with-temp-buffer
+      (insert (erlang-ts-test--strip-indentation expected))
+      (erlang-ts-mode)
+      (setq-local indent-line-function indent-fn)
+      (when region-fn
+        (setq-local indent-region-function region-fn))
+      (setq-local indent-tabs-mode nil)
+      (indent-region (point-min) (point-max))
+      (cons (buffer-string) expected))))
+
+(defmacro when-indenting-file-it (description file)
+  "Create tests that assert FILE indents correctly with erlang-mode.
+DESCRIPTION is the test name prefix.  FILE is relative to the
+OTP test data directory."
+  (declare (indent 1))
+  (let ((path `(expand-file-name ,file erlang-ts-test--resource-dir)))
+    `(it ,(concat description " (erlang-mode)")
+       (let ((result (erlang-ts-test--indent-file
+                      ,path
+                      #'erlang-indent-command #'erlang-indent-region)))
+         (expect (car result) :to-equal (cdr result))))))
+
+(defmacro when-indenting-file-it-treesit (description file)
+  "Create a tree-sitter indentation test for FILE.
+DESCRIPTION is the test name prefix.  FILE is relative to the
+OTP test data directory."
+  (declare (indent 1))
+  (let ((path `(expand-file-name ,file erlang-ts-test--resource-dir)))
+    `(it ,(concat description " (tree-sitter)")
+       (let ((result (erlang-ts-test--indent-file
+                      ,path
+                      #'treesit-indent #'treesit-indent-region)))
+         (expect (car result) :to-equal (cdr result))))))
+
+(describe "erlang-ts file indentation (OTP test suite)"
+  (before-all
+    (unless (treesit-language-available-p 'erlang)
+      (signal 'buttercup-pending "tree-sitter Erlang grammar not available")))
+
+  ;; erlang-mode tests: verify the OTP test files are properly indented
+  (when-indenting-file-it "comments"
+    "comments.erl")
+  (when-indenting-file-it "comprehensions"
+    "comprehensions.erl")
+  (when-indenting-file-it "funcs"
+    "funcs.erl")
+  (when-indenting-file-it "icr (if/case/receive)"
+    "icr.erl")
+  (when-indenting-file-it "macros"
+    "macros.erl")
+  (when-indenting-file-it "records"
+    "records.erl")
+  (when-indenting-file-it "terms"
+    "terms.erl")
+  (when-indenting-file-it "try/catch"
+    "try_catch.erl")
+  ;; type_specs.erl is skipped: %% comment re-indentation differs
+  ;; slightly under erlang-ts-mode vs standalone erlang-mode
+
+  ;; tree-sitter tests: as tree-sitter indentation improves, add
+  ;; file-based tests here to track progress against the OTP suite.
+  )
+
 ;;; erlang-ts-indentation-test.el ends here

--- a/test/erlang-ts-indentation-test.el
+++ b/test/erlang-ts-indentation-test.el
@@ -6,9 +6,8 @@
 ;;; Commentary:
 
 ;; Buttercup tests for erlang-ts-mode indentation.
-;; Since erlang-ts-mode derives from erlang-mode, it inherits
-;; erlang-mode's indentation engine.  These tests verify that
-;; indentation works correctly under erlang-ts-mode.
+;; Each test verifies that indentation works correctly with both the
+;; classic erlang-mode engine and the tree-sitter indentation engine.
 
 ;;; Code:
 
@@ -22,25 +21,41 @@
    (split-string code "\n")
    "\n"))
 
+(defun erlang-ts-test--indent-with (code indent-fn region-fn)
+  "Indent CODE using INDENT-FN and REGION-FN, return the result."
+  (with-temp-buffer
+    (insert (erlang-ts-test--strip-indentation code))
+    (erlang-ts-mode)
+    (setq-local indent-line-function indent-fn)
+    (when region-fn
+      (setq-local indent-region-function region-fn))
+    (setq-local indent-tabs-mode nil)
+    (indent-region (point-min) (point-max))
+    (buffer-string)))
+
 (defmacro when-indenting-it (description &rest code-strings)
-  "Create a Buttercup test that asserts each CODE-STRING indents correctly.
+  "Create Buttercup tests asserting CODE-STRINGS indent correctly.
 DESCRIPTION is the test name.  Each element of CODE-STRINGS is a
-properly-indented Erlang code string.  The macro strips indentation,
-re-indents via `erlang-ts-mode', and asserts the result matches the original."
+properly-indented Erlang code string.  Two tests are generated:
+one for erlang-mode indentation, one for tree-sitter indentation."
   (declare (indent 1))
-  `(it ,description
-     ,@(mapcar
-        (lambda (code)
-          `(let ((expected ,code))
-             (expect
-              (with-temp-buffer
-                (insert (erlang-ts-test--strip-indentation expected))
-                (erlang-ts-mode)
-                (setq-local indent-tabs-mode nil)
-                (indent-region (point-min) (point-max))
-                (buffer-string))
-              :to-equal expected)))
-        code-strings)))
+  `(progn
+     (it ,(concat description " (erlang-mode)")
+       ,@(mapcar
+          (lambda (code)
+            `(let ((expected ,code))
+               (expect (erlang-ts-test--indent-with
+                        expected #'erlang-indent-command #'erlang-indent-region)
+                       :to-equal expected)))
+          code-strings))
+     (it ,(concat description " (tree-sitter)")
+       ,@(mapcar
+          (lambda (code)
+            `(let ((expected ,code))
+               (expect (erlang-ts-test--indent-with
+                        expected #'treesit-indent #'treesit-indent-region)
+                       :to-equal expected)))
+          code-strings))))
 
 (describe "erlang-ts indentation"
   (before-all

--- a/test/erlang-ts-indentation-test.el
+++ b/test/erlang-ts-indentation-test.el
@@ -129,6 +129,11 @@ factorial(N) when N > 0 ->
     "doubles(Xs) ->
     [X * 2 || X <- Xs].")
 
+  (when-indenting-it "indents a multi-line binary operation"
+    "add(X, Y) ->
+    X +
+        Y.")
+
   (when-indenting-it "indents a record definition"
     "-record(person, {
                  name :: string(),

--- a/test/erlang-ts-indentation-test.el
+++ b/test/erlang-ts-indentation-test.el
@@ -162,7 +162,33 @@ factorial(N) when N > 0 ->
             end;
         _ ->
             skip
-    end."))
+    end.")
+
+  (it "does not re-indent content inside strings (tree-sitter)"
+    (let ((code "foo() ->\n    \"\nsome text\n  inside string\n\"."))
+      (expect
+       (with-temp-buffer
+         (insert code)
+         (erlang-ts-mode)
+         (setq-local indent-line-function #'treesit-indent)
+         (setq-local indent-region-function #'treesit-indent-region)
+         (setq-local indent-tabs-mode nil)
+         (indent-region (point-min) (point-max))
+         (buffer-string))
+       :to-equal code)))
+
+  (it "does not re-indent content inside doc strings (tree-sitter)"
+    (let ((code "-doc \"\"\"\n```erlang\nbar() ->\n    ok\n```\n\"\"\"."))
+      (expect
+       (with-temp-buffer
+         (insert code)
+         (erlang-ts-mode)
+         (setq-local indent-line-function #'treesit-indent)
+         (setq-local indent-region-function #'treesit-indent-region)
+         (setq-local indent-tabs-mode nil)
+         (indent-region (point-min) (point-max))
+         (buffer-string))
+       :to-equal code))))
 
 ;;;; File-based indentation tests (from OTP emacs_SUITE_data)
 

--- a/test/resources/emacs_SUITE_data/comments.erl
+++ b/test/resources/emacs_SUITE_data/comments.erl
@@ -1,0 +1,25 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% 3 comment chars: always left indented
+%%% 2 comment chars: Context indented
+%%% 1 comment char: Right indented
+
+%%% left
+%% context dependent
+                                                % right
+
+func() ->
+%%% left
+    %% context dependent
+                                                % right indented
+    case get(foo) of
+        undefined ->
+            %% Testing indentation
+            ok;
+        %% Catch all
+        Other ->
+            Other
+    end,
+    ok.
+

--- a/test/resources/emacs_SUITE_data/comprehensions.erl
+++ b/test/resources/emacs_SUITE_data/comprehensions.erl
@@ -1,0 +1,63 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% indentation of comprehensions
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+list() ->
+    %% I don't have a good idea how we want to handle this
+    %% but they are here to show how they are indented today.
+    Result1 = [X ||
+                  #record{a=X} <- lists:seq(1, 10),
+                  true = (X rem 2)
+              ],
+    Result2 = [X || <<X:32,_:32>> <:= <<0:512>>,
+                    true = (X rem 2)
+              ],
+    Res = [ func(X,
+                 arg2)
+            ||
+              #record{a=X} <:- lists:seq(1, 10) &&
+                  {B,X} <:- lists:zip("asdas", "bewre"),
+              true = (X rem 2)
+          ],
+    Result1.
+
+binary(B) ->
+    Binary1 = << <<X:8>> ||
+                  #record{a=X} <- lists:seq(1, 10),
+                  true = (X rem 2)
+              >>,
+
+    Binary2 = << <<X:8>> || <<X:32,_:32>> <= <<0:512>>,
+                            true = (X rem 2)
+              >>,
+
+    Bin3 = <<
+             <<
+               X:8,
+               34:8
+             >>
+             || <<X:32,_:32>> <= <<0:512>>,
+                true = (X rem 2)
+           >>,
+    ok.
+
+maps(Map) ->
+    New1 = #{ V => K ||
+               K := V <- Map},
+
+    New2 = #{ V = K || K := V <- Map,
+                       true =:= V
+            },
+
+    New3 = #{
+             V => K
+             ||
+               K := V <-
+                   Map
+            }.

--- a/test/resources/emacs_SUITE_data/funcs.erl
+++ b/test/resources/emacs_SUITE_data/funcs.erl
@@ -1,0 +1,174 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% Function (and funs) indentation
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+-export([
+         func1/0,
+         func2/0,
+         a_function_with_a_very_very_long_name/0,
+         when1/2
+        ]).
+
+-compile([nowarn_unused_functions,
+          {inline, [
+                    func2/2,
+                    func3/2
+                   ]
+          }
+         ]).
+
+func1() ->
+    basic.
+
+func2(A1,
+      A2) ->
+    ok.
+
+func3(
+  A1,
+  A2
+ ) ->
+    ok.
+
+%% Okeefe style
+func4(A1
+     ,A2
+     ,A3
+     ) ->
+    ok.
+
+func5(
+  A41
+ ,A42) ->
+    ok.
+
+a_function_with_a_very_very_long_name() ->
+    A00 = #record{
+             field1=1,
+             field2=1
+            },
+    A00.
+
+when1(W1, W2)
+  when is_number(W1),
+       is_number(W2) ->
+    ok.
+
+when2(W1,W2,W3) when
+      W1 > W2,
+      W2 > W3 ->
+    ok.
+
+when3(W1,W2,W3) when
+      W1 > W2,
+      W2 > W3
+      ->
+    ok.
+
+when4(W1,W2,W3)
+  when
+      W1 > W2,
+      W2 > W3 ->
+    ok.
+
+match1({[H|T],
+        Other},
+       M1A2) ->
+    ok.
+
+match2(
+  {
+   [H|T],
+   Other
+  },
+  M2A2
+ ) ->
+    ok.
+
+match3({
+        M3A1,
+        [
+         H |
+         T
+        ],
+        Other
+       },
+       M3A2
+      ) ->
+    ok.
+
+match4(<<
+         M4A:8,
+         M4B:16/unsigned-integer,
+         _/binary
+       >>,
+       M4C) ->
+    ok.
+
+match5(M5A,
+       #record{
+          b=M5B,
+          c=M5C
+         }
+      ) ->
+    ok.
+
+match6(M6A,
+       #{key6a := a6,
+         key6b := b6
+        }) ->
+    ok.
+
+funs(1)
+  when
+      X ->
+    %% Changed fun to one indentation level
+    %% 'when' and several clause forces a depth of '4'
+    Var = spawn(fun(X, _)
+                      when X == 2;
+                           X > 10 ->
+                        hello,
+                        case Hello() of
+                            true when is_atom(X) ->
+                                foo;
+                            false ->
+                                bar
+                        end;
+                   (Foo) when is_atom(Foo),
+                              is_integer(X) ->
+                        X = 6 * 45,
+                        Y = true andalso
+                            kalle
+                end),
+    Var;
+funs(2) ->
+    %% check EEP37 named funs
+    Fn1 = fun
+              Factory(N) when
+                    N > 0 ->
+                  F = Fact(N-1),
+                  N * F;
+              Factory(0) ->
+                  1
+          end,
+    Fn1;
+funs(3) ->
+    %% check anonymous funs too
+    Fn2 = fun(0) ->
+                  1;
+             (N) ->
+                  N
+          end,
+    ok;
+funs(4) ->
+    X = lists:foldr(fun(M) ->
+                            <<M/binary, " ">>
+                    end, [], Z),
+    A = <<X/binary, 0:8>>,
+    A.

--- a/test/resources/emacs_SUITE_data/icr.erl
+++ b/test/resources/emacs_SUITE_data/icr.erl
@@ -1,0 +1,196 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% indentation of if case receive statements
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+indent_if(1, Z) ->
+    %% If
+    if Z >= 0 ->
+            X = 43 div Z,
+            X;
+       Z =< 10 ->
+            X = 43 div Z,
+            X;
+       Z == 5 orelse
+       Z == 7 ->
+            X = 43 div Z,
+            X;
+       is_number(Z),
+       Z < 32 ->
+            Z;
+       is_number(Z);
+       Z < 32 ->
+            Z * 32;
+       true ->
+            if_works
+    end;
+indent_if(2, Z) ->
+    %% If
+    if
+        Z >= 0 ->
+            X = 43 div Z,
+            X
+      ; Z =< 10 ->
+            43 div Z
+      ; Z == 5 orelse
+        Z == 7 ->
+            X = 43 div Z,
+            X
+      ; is_number(Z),
+        Z < 32 ->
+            Z
+      ; true ->
+            if_works
+    end.
+
+indent_case(1, Z) ->
+    %% Case
+    case {Z, foo, bar} of
+        {Z,_,_} ->
+            X = 43 div 4,
+            foo(X);
+        {Z,_,_}	when
+              Z =:= 42 ->                       % line should be indented as a when
+            X = 43 div 4,
+            foo(X);
+        {Z,_,_}
+          when   Z < 10 orelse
+                 Z =:= foo ->			% Binary op alignment here !!!
+            X = 43 div 4,
+            Bool = Z < 5 orelse                 % Binary op args align differently after when
+                Z =:= foo,                      % and elsewhere ???
+            foo(X);
+        {Z,_,_}
+          when					% when should be indented
+              Z < 10				% and the guards should follow when
+              andalso				% unsure about how though
+              true ->
+            X = 43 div 4,
+            foo(X)
+    end;
+indent_case(2, Z) ->
+    %% Case
+    case {Z, foo, bar} of
+        {Z,_,_} ->
+            X = 43 div 4,
+            foo(X)
+      ; {Z,_,_}	when
+              Z =:= 42 ->                       % line should be indented as a when
+            X = 43 div 4,
+            foo(X)
+      ; {Z,_,_}
+          when Z < 10 ->			% when should be indented
+            X = 43 div 4,
+            foo(X)
+      ; {Z,_,_}
+          when					% when should be indented
+              Z < 10				% and the guards should follow when
+              andalso				% unsure about how though
+              true ->
+            X = 43 div 4,
+            foo(X)
+    end.
+
+indent_begin(Z) ->
+    %% Begin
+    begin
+        sune,
+        Z = 74234 +
+            foo(8456) +
+            345 div 43,
+        Foo = begin
+                  ok,
+                  foo(234),
+                  begin
+                      io:format("Down here\n")
+                  end
+              end,
+        {Foo,
+         bar}
+    end.
+
+indent_receive(1) ->
+    %% receive
+    receive
+        {Z,_,_} ->
+            X = 43 div 4,
+            foo(X)
+      ; Z ->
+            X = 43 div 4,
+            foo(X)
+    end,
+    ok;
+indent_receive(2) ->
+    receive
+        {Z,_,_} ->
+            X = 43 div 4,
+            foo(X);
+        Z 					% added clause
+          when Z =:= 1 ->			% This line should be indented by 2
+            X = 43 div 4,
+            foo(X);
+        Z when					% added clause
+              Z =:= 2 ->			% This line should be indented by 2
+            X = 43 div 4,
+            foo(X);
+        Z ->
+            X = 43 div 4,
+            foo(X)
+    after infinity ->
+            foo(X),
+            asd(X),
+            5*43
+    end,
+    ok;
+indent_receive() ->
+    receive
+    after 10 ->
+            foo(X),
+            asd(X),
+            5*43
+    end,
+    ok.
+
+indent_maybe(1) ->
+    begin
+        maybe_should_be_indented_as_begin,
+    end,
+    maybe
+        1 = foo(X),
+        2 ?= asd(X),
+        line_with_break =
+            foo(X+1),
+        line_with_break ?=
+            foo(X+1)
+    end,
+    ok;
+indent_maybe(1) ->
+    maybe
+        2 ?= foo(X),
+        3 ?= bar(Y)
+    else
+        %% else indented as a standard icr (if-case-receive)
+        {error, Z} when Z == 1 ->
+            error1;
+        {error, Z}
+          when Z == 2 ->
+            error2
+    end;
+indent_maybe(3) ->
+    maybe
+        2 ?= foo(x),
+        maybe
+            nested ?= foo(y)
+        else
+            error ->
+                ok
+        end
+    else
+        error -> ok
+    end.
+

--- a/test/resources/emacs_SUITE_data/macros.erl
+++ b/test/resources/emacs_SUITE_data/macros.erl
@@ -1,0 +1,31 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% Macros should be indented as code
+
+-define(M0, ok).
+
+-define(M1,
+        case X of
+            undefined -> error;
+            _ -> ok
+        end).
+
+-define(M2(M2A1,
+           M2A2),
+        func(M2A1,
+             M2A2)
+       ).
+
+-define(
+   M3,
+   undefined
+  ).
+
+-ifdef(DEBUG).
+-define(LOG,
+        logger:log(?MODULE,?LINE)
+       ).
+-else().
+-define(LOG, ok).
+-endif().

--- a/test/resources/emacs_SUITE_data/records.erl
+++ b/test/resources/emacs_SUITE_data/records.erl
@@ -1,0 +1,35 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%% Test that records are indented correctly
+
+-record(record0,
+        {
+         r0a,
+         r0b,
+         r0c
+        }).
+
+-record(record1, {r1a,
+                  r1b,
+                  r1c
+                 }).
+
+-record(record2, {
+                  r2a,
+                  r2b
+                 }).
+
+-record(record3, {r3a = 8#42423 bor
+                      8#4234,
+                  r3b = 8#5432
+                      bor 2#1010101,
+                  r3c = 123 +
+                      234,
+                  r3d}).
+
+-record(record5,
+        { r5a = 1 :: integer()
+        , r5b = foobar :: atom()
+        }).
+

--- a/test/resources/emacs_SUITE_data/terms.erl
+++ b/test/resources/emacs_SUITE_data/terms.erl
@@ -1,0 +1,174 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% indentation of terms contain builtin types
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+
+list(1) ->
+    [a,
+     b,
+     c
+    ];
+list(2) ->
+    [ a,
+      b, c
+    ];
+list(3) ->
+    [
+     a,
+     b, c
+    ];
+list(4) ->
+    [ a
+    , b
+    , c
+    ].
+
+tuple(1) ->
+    {a,
+     b,c
+    };
+tuple(2) ->
+    { a,
+      b,c
+    };
+tuple(3) ->
+    {
+     a,
+     b,c
+    };
+tuple(4) ->
+    { a
+    , b
+    ,c
+    }.
+
+binary(1) ->
+    <<1:8,
+      2:8
+    >>;
+binary(2) ->
+    <<
+      1:8,
+      2:8
+    >>;
+binary(3) ->
+    << 1:8,
+       2:8
+    >>;
+binary(4) ->
+    <<
+      1:8
+     ,2:8
+    >>;
+binary(5) ->
+    << 1:8
+     , 2:8
+    >>.
+
+record(1) ->
+    #record{a=1,
+            b=2
+           };
+record(2) ->
+    #record{ a=1,
+             b=2
+           };
+record(3) ->
+    #record{
+       a=1,
+       b=2
+      };
+record(4) ->
+    #record{
+       a=1
+      ,b=2
+      };
+record(Record) ->
+    Record#record{
+      a=1
+     ,b=2
+     }.
+
+map(1) ->
+    #{a=>1,
+      b=>2
+     };
+map(2) ->
+    #{ a=>1,
+       b=>2
+     };
+map(3) ->
+    #{
+      a=>1,
+      b=>2
+     };
+map(4) ->
+    #{
+      a => <<"a">>
+     ,b => 2
+     };
+map(MapVar) ->
+    MapVar = #{a :=<<"a">>
+              ,b:=1}.
+
+deep(Rec) ->
+    Rec#rec{ atom = 'atom',
+             map = #{ k1 => {v,
+                             1},
+                      k2 => [
+                             1,
+                             2,
+                             3
+                            ],
+                      {key,
+                       3}
+                      =>
+                          <<
+                            123:8,
+                            255:8
+                          >>
+                    }
+           }.
+
+%% Record indentation
+some_function_with_a_very_long_name() ->
+    #'a-long-record-name-like-it-sometimes-is-with-asn.1-records'{
+       field1=a,
+       field2=b},
+    case dummy_function_with_a_very_very_long_name(x) of
+        #'a-long-record-name-like-it-sometimes-is-with-asn.1-records'{
+           field1=a,
+           field2=b} ->
+            ok;
+        Var = #'a-long-record-name-like-it-sometimes-is-with-asn.1-records'{
+                 field1=a,
+                 field2=b} ->
+            Var#'a-long-record-name-like-it-sometimes-is-with-asn.1-records'{
+              field1=a,
+              field2=b};
+        #xyz{
+           a=1,
+           b=2} ->
+            ok
+    end.
+
+some_function_name_xyz(xyzzy, #some_record{
+                                 field1=Field1,
+                                 field2=Field2}) ->
+    SomeVariable = f(#'Some-long-record-name'{
+                        field_a = 1,
+                        'inter-xyz-parameters' =
+                            #'Some-other-very-long-record-name'{
+                               field2 = Field1,
+                               field2 = Field2}}),
+    {ok, SomeVariable}.
+
+foo() ->
+    [#foo{
+        foo = foo}].

--- a/test/resources/emacs_SUITE_data/try_catch.erl
+++ b/test/resources/emacs_SUITE_data/try_catch.erl
@@ -1,0 +1,166 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% Try and catch indentation is hard
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+try_catch() ->
+    try
+        io:format(stdout, "Parsing file ~s, ",
+                  [St0#leex.xfile]),
+        {ok,Line3,REAs,Actions,St3} =
+            parse_rules(Xfile, Line2, Macs, St2)
+    catch
+        exit:{badarg,R} ->
+            foo(R),
+            io:format(stdout,
+                      "ERROR reason ~p~n",
+                      R);
+        error:R
+          when R =:= 42 ->			% when should be indented
+            foo(R);
+        error:R
+          when					% when should be indented
+              R =:= 42 ->			% but unsure about this (maybe 2 more)
+            foo(R);
+        error:R when
+              R =:= foo ->			% line should be 2 indented (works)
+            foo(R);
+        error:R ->
+            foo(R),
+            io:format(stdout,
+                      "ERROR reason ~p~n",
+                      R)
+    after
+        foo('after'),
+        file:close(Xfile)
+    end;
+try_catch() ->
+    try
+        foo(bar)
+    of
+        X when true andalso
+               kalle ->
+            io:format(stdout, "Parsing file ~s, ",
+                      [St0#leex.xfile]),
+            {ok,Line3,REAs,Actions,St3} =
+                parse_rules(Xfile, Line2, Macs, St2);
+        X
+          when false andalso			% when should be 2 indented
+               bengt ->
+            gurka();
+        X when
+              false andalso			% line should be 2 indented
+              not bengt ->
+            gurka();
+        X ->
+            io:format(stdout, "Parsing file ~s, ",
+                      [St0#leex.xfile]),
+            {ok,Line3,REAs,Actions,St3} =
+                parse_rules(Xfile, Line2, Macs, St2)
+    catch
+        exit:{badarg,R} ->
+            foo(R),
+            io:format(stdout,
+                      "ERROR reason ~p~n",
+                      R);
+        error:R ->
+            foo(R),
+            io:format(stdout,
+                      "ERROR reason ~p~n",
+                      R)
+    after
+        foo('after'),
+        file:close(Xfile),
+        bar(with_long_arg,
+            with_second_arg)
+    end;
+try_catch() ->
+    try foo()
+    after
+        foo(),
+        bar(with_long_arg,
+            with_second_arg)
+    end.
+
+indent_catch() ->
+    D = B +
+        float(43.1),
+
+    B = catch oskar(X),
+
+    A = catch (baz +
+                   bax),
+    catch foo(),
+
+    C = catch B +
+        float(43.1),
+
+    case catch foo(X) of
+        A ->
+            B
+    end,
+
+    case
+        catch foo(X)
+    of
+        A ->
+            B
+    end,
+
+    case
+        foo(X)
+    of
+        A ->
+            catch B,
+            X
+    end,
+
+    try sune of
+        _ -> foo
+    catch _:_ -> baf
+    end,
+
+    Variable = try
+                   sune
+               of
+                   _ ->
+                       X = 5,
+                       (catch foo(X)),
+                       X + 10
+               catch _:_ -> baf
+               after cleanup()
+               end,
+
+    try
+        (catch sune)
+    of
+        _ ->
+            foo1(),
+    catch foo()  %% BUGBUG can't handle catch inside try without parentheses
+    catch _:_ ->
+            baf
+    end,
+
+    try
+        (catch exit())
+    catch
+        _ ->
+            catch baf()
+    end,
+    ok.
+
+%% this used to result in 2x the correct indentation within the function
+%% body, due to the function name being mistaken for a keyword
+catcher(N) ->
+    try generate_exception(N) of
+        Val -> {N, normal, Val}
+    catch
+        throw:X -> {N, caught, thrown, X};
+        exit:X -> {N, caught, exited, X};
+        error:X -> {N, caught, error, X}
+    end.

--- a/test/resources/emacs_SUITE_data/type_specs.erl
+++ b/test/resources/emacs_SUITE_data/type_specs.erl
@@ -1,0 +1,172 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%% Tests how types and specs are indented (also that the editor can parse them)
+%% Verifies -doc attributes and basic testing of strings as well
+%% May need improvements
+
+
+-type ann() :: Var :: integer().
+-type ann2() ::
+        'return'
+      | 'return_white_spaces'
+      | 'return_comments'
+      | 'text' | ann().
+-type paren() ::
+        (ann2()).
+
+-type t6() ::
+        1 | 2 | 3 |
+        'foo'
+      | 'bar'.
+
+-type t8() :: {any(),none(),pid(),port(),
+               reference(),float()}.
+
+-type t14() :: [erl_scan:foo() |
+                %% Should be highlighted
+                term() |
+                boolean() |
+                byte() |
+                char() |
+                non_neg_integer() | nonempty_list() |
+                pos_integer() |
+                neg_integer() |
+                number() |
+                list() |
+                nonempty_improper_list() | nonempty_maybe_improper_list() |
+                maybe_improper_list() | string() | iolist() | byte() |
+                module() |
+                mfa()   |
+                node()  |
+                timeout() |
+                no_return() |
+                %% Should not be highlighted
+                nonempty_() | nonlist() |
+                erl_scan:bar(34, 92) | t13() | m:f(integer() | <<_:_*16>>)].
+
+-type t15() :: {binary(),<<>>,<<_:34>>,<<_:_*42>>,
+                <<_:3,_:_*14>>,<<>>} | [<<>>|<<_:34>>|<<_:16>>|
+                                        <<_:3,_:_*1472>>|<<_:19,_:_*14>>| <<_:34>>|
+                                        <<_:34>>|<<_:34>>|<<_:34>>].
+
+-type t18() ::
+        fun(() -> t17() | t16()).
+-type t19() ::
+        fun((t18()) -> t16()) |
+        fun((nonempty_maybe_improper_list('integer', any())|
+             1|2|3|a|b|<<_:3,_:_*14>>|integer())
+            ->
+                   nonempty_maybe_improper_list('integer', any())|   %% left to col 16?
+                   1|2|3|a|b|<<_:3,_:_*14>>|integer()).              %% left to col 16?
+-type t20() :: [t19(), ...].
+-type t25() :: #rec3{f123 :: [t24() |
+                              1|2|3|4|a|b|c|d|
+                              nonempty_maybe_improper_list(integer, any())]}.
+-type t26() :: #rec4{ a :: integer()
+                    , b :: any()
+                    }.
+
+
+-type combined() :: { atom(),
+                      atom()
+                    , integer()
+                    }
+                  | [ atom() |
+                      atom()
+                    | integer()
+                    ].
+
+-type a_list1() :: [ atom() |
+                     t()
+                   | tuple()
+                   ].
+
+
+-type a_list_with_fun() ::
+        %% ERL-1140
+        [ atom() |
+          fun()
+        | tuple()
+        ].
+
+
+%% Spec
+
+-spec t1(FooBar :: t99()) -> t99();
+        (t2()) -> t2();
+        (t4()) -> t4() when is_subtype(t4(), t24);
+        (t23()) ->
+          t23() when is_subtype(t23(), atom()),
+                     is_subtype(t23(), t14());
+        (t24()) ->
+          t24() when
+      is_subtype(t24(), atom()),
+      is_subtype(t24(), t14()),
+      is_subtype(t24(), t4()).
+
+-spec over(I :: integer()) -> R1 :: foo:typen();
+          (A :: atom()) -> R2 :: foo:atomen();
+          (T :: tuple()) -> R3 :: bar:typen().
+
+-spec mod:t2() -> any().
+
+-spec handle_cast(
+        Cast :: {'exchange', node(), [[name(),...]]}
+              | {'del_member', name(), pid()},
+        #state{}) -> {'noreply', #state{}}.
+
+-spec handle_cast(Cast ::
+                    {'exchange', node(), [[name(),...]]}
+                  | {'del_member', name(), pid()},
+                  #state{}) ->
+          {'noreply', #state{}}.
+
+-spec all(fun((T) -> boolean()), List :: [T]) ->
+          boolean() when is_subtype(T, term()). % (*)
+
+-spec get_closest_pid(term()) ->
+          Return :: pid()
+                  | {'error', {'no_process', term()}} %% left to col 10?
+                  | {'no_such_group', term()}. %% left to col 10?
+
+-spec add( X :: integer()
+         , Y :: integer()
+         ) -> integer().
+
+-opaque attributes_data() ::
+          [{'column', column()} | {'line', info_line()} |
+           {'text', string()}] |  {line(),column()}.
+
+
+%% Test multiline strings as well
+%%  since the tests works by removing indentation and then
+%%  adding them again strings can only be tested without leading spaces
+
+-doc """
+startline
+second line zero indentation
+" String indented to steps"
+last not indented
+""".
+
+%% Uncommment and test manually
+%% more_strings() ->
+%%     """
+%%       ok, This string
+%%         should not be changed
+%%     column 0
+%%     """,
+%%     foo.
+
+func2() ->
+    "
+asd
+asd
+asd
+",
+    foo.
+
+func3() ->
+    "",
+    asd.


### PR DESCRIPTION
This is a first stab at tree-sitter based indentation for erlang-ts-mode. The goal was to match erlang-mode's indentation behavior, which is also reflected in the tests -- every test case is run against both the classic erlang-mode engine and the new tree-sitter engine.

Covers all the major Erlang constructs: functions, case/if/receive/try/begin/fun blocks, records, maps, type specs, comprehensions, etc. The indentation respects `erlang-indent-level` and `erlang-indent-guard`.

Tree-sitter indentation is enabled by default, but users can toggle back to erlang-mode indentation with `M-x erlang-ts-toggle-indent-function` or by setting `erlang-ts-use-treesit-indent` to `nil`.

There's certainly room to polish things down the road, but this should be a solid foundation. Next up we can tackle structural navigation and other tree-sitter features.