### PR TITLE
Improve documentation

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,4 +1,5 @@
 test/
+doc/
 Eldev
 .eldev/
 .github/

--- a/README.md
+++ b/README.md
@@ -1,41 +1,141 @@
+# erlang-ts — Emacs Erlang mode using tree-sitter
 
-# Emacs Erlang mode using treesitter #
+[![MELPA](https://melpa.org/packages/erlang-ts-badge.svg)](https://melpa.org/#/erlang-ts)
+[![CI](https://github.com/erlang/emacs-erlang-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/erlang/emacs-erlang-ts/actions/workflows/ci.yml)
 
-Requires emacs-29 compiled with treesitter support.
+Requires Emacs 29+ compiled with tree-sitter support.
 
-Uses tree-sitter for syntax highlighting and indentation. Other features
-(compilation, REPL, etc.) are inherited from erlang-mode.
+`erlang-ts-mode` is a tree-sitter powered major mode for editing Erlang code.
+It derives from [erlang-mode](https://github.com/erlang/otp/tree/master/lib/tools/emacs)
+and progressively replaces its features with tree-sitter based implementations.
 
-There is a lot of work to do to convert the old erlang mode to use tree-sitter, but
-by re-using the old one we can do the conversion little by little.
+## Features
 
-Help is appreciated.
+- Tree-sitter based font-locking (4 levels)
+- Tree-sitter based indentation (experimental, opt-in)
+- Embedded markdown highlighting in `-doc` and `-moduledoc` attributes (Emacs 30+)
+- Imenu support for functions, macros, records, and types
+- Easy grammar installation via `M-x erlang-ts-install-grammar`
+- LSP integration (Eglot language ID configured automatically)
+- Everything else inherited from erlang-mode (compilation, REPL, navigation, etc.)
 
-# Install #
+## Installation
 
-Add to your .emacs file:
+### MELPA
 
+`erlang-ts` is available on [MELPA](https://melpa.org/#/erlang-ts). If you
+have MELPA in your `package-archives`, install it with:
+
+    M-x package-install <RET> erlang-ts <RET>
+
+Or with `use-package`:
+
+```emacs-lisp
+(use-package erlang-ts
+  :ensure t
+  :mode ("\\.erl\\'" . erlang-ts-mode))
 ```
- (add-to-list 'load-path "~/emacs-erlang-ts")
- (add-to-list 'treesit-language-source-alist '(erlang "https://github.com/WhatsApp/tree-sitter-erlang"))
 
- (use-package erlang-ts
-     :mode ("\\.erl\\'" . erlang-ts-mode)
-     :defer 't)
+### From GitHub
+
+You can install directly from the repository:
+
+    M-x package-vc-install <RET> https://github.com/erlang/emacs-erlang-ts <RET>
+
+Or with `use-package` on Emacs 30+:
+
+```emacs-lisp
+(use-package erlang-ts
+  :vc (:url "https://github.com/erlang/emacs-erlang-ts" :rev :newest)
+  :mode ("\\.erl\\'" . erlang-ts-mode))
 ```
-Install/compile erlang treesitter support (first time or update treesitter grammer):
 
+The first time you open an Erlang file, the mode will offer to install the
+tree-sitter grammar if it's not already available. You can also install it
+manually with `M-x erlang-ts-install-grammar`.
+
+## Customization
+
+### Font-locking
+
+`erlang-ts-mode` provides 4 levels of font-locking. The default level in
+Emacs is 3. You can change it with:
+
+```emacs-lisp
+;; this font-locks everything erlang-ts supports
+(setq treesit-font-lock-level 4)
 ```
-  M-x treesit-install-language-grammar
-  Language: erlang
+
+You can also use `M-x erlang-font-lock-level-1` through
+`M-x erlang-font-lock-level-4` to change the level interactively.
+
+The font-lock features available at each level are:
+
+**Level 1** (minimal):
+
+- `string` — string literals
+- `comment` — comments
+- `keyword` — language keywords: `case`, `of`, `end`, `if`, `receive`, `try`, `catch`, `fun`, `begin`, `when`, etc.
+- `doc` — doc attribute strings (`-doc`, `-moduledoc`)
+
+**Level 2** (add preprocessor, definitions, types):
+
+- `preprocessor` — module attributes, preprocessor directives, macro calls
+- `operator-atoms` — operator keywords
+- `definition` — function names, callback and spec definitions
+- `type` — type names, record names, record field names
+
+**Level 3** (default):
+
+- `builtin` — built-in functions and guards
+- `variable` — variables
+- `guards` — guard expressions
+- `function-call` — function calls
+- `constant` — quoted atoms, char literals, predefined macros
+
+**Level 4** (maximum detail):
+
+- `operator` — operators: `->`, `||`, `+`, `-`, `>=`, etc.
+- `remote-module` — module names in remote calls (`io:format`)
+- `delimiter` — delimiters: `.`, `,`, `;`, `|`
+- `bracket` — brackets: `()`, `[]`, `{}`, `<<>>`
+- `number` — numeric literals
+- `index-atom` — record field names in expressions, map keys
+
+#### Selecting features
+
+You don't have to use the level system. If you want fine-grained control over
+what gets highlighted, you can cherry-pick individual features using
+`treesit-font-lock-recompute-features`:
+
+```emacs-lisp
+(defun my-erlang-ts-font-lock-setup ()
+  (treesit-font-lock-recompute-features
+   ;; enable these features
+   '(comment string keyword doc
+     preprocessor definition type
+     builtin variable constant
+     operator number)
+   ;; disable these features
+   '(bracket delimiter)))
+
+(add-hook 'erlang-ts-mode-hook #'my-erlang-ts-font-lock-setup)
 ```
 
-# Customization #
+#### Customizing faces
 
-Customize `treesit-font-lock-level` variable to increase/decrease the coloring,
-or use `M-x erlang-font-lock-level-1-4` to change it.
+The faces used are standard `font-lock-*-face` faces, so any theme applies
+automatically. To tweak specific faces in erlang-ts buffers only, use
+buffer-local remapping:
 
-## Indentation ##
+```emacs-lisp
+(add-hook 'erlang-ts-mode-hook
+  (lambda ()
+    (face-remap-add-relative 'font-lock-type-face
+                             :foreground "DarkSeaGreen4")))
+```
+
+### Indentation
 
 By default, `erlang-ts-mode` uses erlang-mode's classic indentation engine.
 An experimental tree-sitter based indentation engine is also available.
@@ -45,13 +145,13 @@ Both respect the standard `erlang-indent-level` (default 4) and
 To try the tree-sitter indentation, use `M-x erlang-ts-toggle-indent-function`
 or set `erlang-ts-use-treesit-indent` to `t`.
 
-### Known indentation limitations ###
+#### Known indentation limitations
 
 The tree-sitter indentation handles common Erlang constructs well but has
 some known gaps compared to erlang-mode. Improvements are ongoing and
 contributions are welcome!
 
-#### Continuation lines ####
+##### Continuation lines
 
 Multi-line expressions where a line continues an expression from the
 previous line may not align correctly in all cases:
@@ -70,7 +170,7 @@ try
 catch ...
 ```
 
-#### Inline if clauses ####
+##### Inline if clauses
 
 When `if` has clauses on the same line, subsequent clauses use a slightly
 different alignment than erlang-mode:
@@ -91,7 +191,7 @@ different alignment than erlang-mode:
     end
 ```
 
-#### Comma-first / pipe-first style ####
+##### Comma-first / pipe-first style
 
 Code using comma-first or pipe-first formatting may not indent as expected:
 
@@ -109,7 +209,7 @@ Code using comma-first or pipe-first formatting may not indent as expected:
 ]
 ```
 
-#### Records with `{` on a separate line ####
+##### Records with `{` on a separate line
 
 When the opening brace is on a different line from `-record(name,`:
 
@@ -127,7 +227,7 @@ When the opening brace is on a different line from `-record(name,`:
 If you encounter indentation issues, you can always switch to erlang-mode's
 indentation with `M-x erlang-ts-toggle-indent-function`.
 
-## Markdown in doc attributes ##
+### Markdown in doc attributes
 
 `erlang-ts-mode` can highlight markdown syntax (bold, italic, code spans, links)
 inside `-doc` and `-moduledoc` attributes using the `markdown-inline` tree-sitter
@@ -137,8 +237,78 @@ available.
 Install the grammar with `M-x erlang-ts-install-markdown-grammar`. To disable
 markdown highlighting, set `erlang-ts-use-markdown-inline` to `nil`.
 
-# Hacking #
+### LSP (Eglot) integration
+
+`erlang-ts-mode` automatically configures the Eglot language ID for Erlang.
+To use Eglot with [erlang_ls](https://github.com/erlang-ls/erlang_ls):
+
+```emacs-lisp
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '(erlang-ts-mode . ("erlang_ls"))))
+
+(add-hook 'erlang-ts-mode-hook #'eglot-ensure)
+```
+
+## Relationship with erlang-mode
+
+`erlang-ts-mode` derives from `erlang-mode` and inherits all of its
+functionality. The following features are overridden with tree-sitter
+implementations:
+
+| Feature          | erlang-mode     | erlang-ts-mode           |
+|------------------|-----------------|--------------------------|
+| Font-locking     | Regex-based     | Tree-sitter (4 levels)   |
+| Indentation      | Custom engine   | Both (see below)         |
+| Imenu            | Regex-based     | Tree-sitter based        |
+| Doc highlighting | Not available   | Embedded markdown-inline |
+
+For indentation, `erlang-ts-mode` defaults to erlang-mode's engine. An
+experimental tree-sitter indentation engine is available via
+`erlang-ts-use-treesit-indent` (see [Indentation](#indentation)).
+
+Everything else (compilation, REPL, shell, navigation, skeleton templates,
+keybindings, etc.) is inherited directly from erlang-mode.
+
+## Migrating from erlang-mode
+
+### File associations
+
+`erlang-ts-mode` registers the same file patterns as `erlang-mode` (`.erl`,
+`.hrl`, `.xrl`, `.yrl`, `.escript`, etc.) during setup. If both modes are
+installed, the last one to load wins. To ensure `erlang-ts-mode` takes
+precedence, load it after `erlang-mode`:
+
+```emacs-lisp
+(use-package erlang-ts
+  :ensure t
+  :after erlang
+  :mode ("\\.erl\\'" . erlang-ts-mode))
+```
+
+### What you gain
+
+- Tree-sitter powered font-locking (more accurate, 4 configurable levels)
+- Tree-sitter powered imenu
+- Embedded markdown highlighting in doc attributes
+- A foundation for future tree-sitter features (navigation, structural
+  editing, etc.)
+
+### What's the same
+
+Since `erlang-ts-mode` derives from `erlang-mode`, all of its functionality
+is preserved: compilation, REPL, shell, navigation, keybindings, skeleton
+templates, and more.
+
+### What to watch out for
+
+- The tree-sitter indentation is experimental and opt-in. By default you
+  get erlang-mode's indentation, so there should be no surprises.
+- `erlang-ts-mode` requires the Erlang tree-sitter grammar to be installed.
+  The mode will prompt you to install it on first use.
+
+## Hacking
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to run tests,
-and guidelines for submitting changes.
-
+and guidelines for submitting changes. Architecture and design notes live in
+[doc/DESIGN.md](doc/DESIGN.md).

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -1,0 +1,194 @@
+# erlang-ts Design Notes
+
+## Architecture
+
+`erlang-ts-mode` derives from `erlang-mode` and incrementally replaces its
+features with tree-sitter implementations.  This allows users to benefit from
+tree-sitter font-locking and indentation while keeping all of erlang-mode's
+battle-tested functionality (compilation, REPL, navigation, etc.).
+
+The mode setup happens in two stages:
+
+1. `erlang-mode` initializes everything (keybindings, syntax table, comment
+   handling, etc.)
+2. `erlang-ts-setup` overrides font-lock, imenu, indentation, and
+   syntax-propertize with tree-sitter implementations
+
+## Lazy initialization
+
+Top-level `defvar` forms that call `treesit-font-lock-rules` or
+`treesit-query-compile` would fail during byte-compilation if the tree-sitter
+grammar isn't installed.  To avoid this, font-lock rules and the
+syntax-propertize query are computed lazily on first use:
+
+```elisp
+(defvar erlang-ts-font-lock-rules nil
+  "Computed lazily on first use.")
+
+(defun erlang-ts--build-font-lock-rules ()
+  "Build tree-sitter font-lock rules for Erlang."
+  (treesit-font-lock-rules ...))
+
+;; In erlang-ts-setup:
+(unless erlang-ts-font-lock-rules
+  (setq erlang-ts-font-lock-rules (erlang-ts--build-font-lock-rules)))
+```
+
+This follows the same pattern used by
+[neocaml](https://github.com/bbatsov/neocaml) and avoids issues with
+byte-compilation across different Emacs versions.
+
+## Font-locking
+
+Font-lock rules are defined in `erlang-ts--build-font-lock-rules` using
+`treesit-font-lock-rules`.  The features are organized into 4 levels:
+
+- **Level 1**: string, comment, keyword, doc
+- **Level 2**: preprocessor, operator-atoms, definition, type
+- **Level 3** (default): builtin, variable, guards, function-call, constant
+- **Level 4**: operator, remote-module, delimiter, bracket, number, index-atom
+
+The rules use Erlang-specific predicates like `erlang-ts-in-type-context-p`
+(to fontify type names only in type contexts) and
+`erlang-ts-predefined-macro-p` (to highlight built-in macros).
+
+## Indentation
+
+Tree-sitter indentation is driven by `treesit-simple-indent-rules` — a list
+of `(MATCHER ANCHOR OFFSET)` triples tried in order.  The first matching rule
+wins.
+
+The rules in `erlang-ts--indent-rules` are roughly ordered as follows:
+
+1. **Comment conventions** — `%%%` at column 0, `%%` context-dependent,
+   `%` at `comment-column`
+2. **String preservation** — `no-indent` for lines inside strings to avoid
+   changing string values
+3. **Top-level** — `(parent-is "source_file")` pins everything at column 0
+4. **Closing delimiters** — `end`, `)`, `]`, `}` align with their opening
+   counterpart
+5. **Keyword alignment** — `catch` aligns with `try`, `receive_after` aligns
+   with `receive`
+6. **Clause body** — special double-indent for `fun_clause`, `receive_after`,
+   and inline `if_clause` bodies
+7. **Block constructs** — children of `case_expr`, `if_expr`, `try_expr`,
+   `receive_expr`, etc.
+8. **Record/map fields** — align after `{`
+9. **Function arguments** — smart alignment: after `(` when content follows,
+   `erlang-argument-indent` from function name when `(` is at EOL (Okeefe
+   style)
+10. **Collections** — align after opening delimiter (`[`, `{`)
+11. **Multi-line expressions** — `binary_op_expr`, `match_expr`, `pipe`, etc.
+12. **Type specs** — body indented at 2x `erlang-indent-level`
+13. **Error recovery** — `(parent-is "ERROR")` provides basic indentation for
+    incomplete code
+14. **Catch-all** — `(no-node prev-line 0)` preserves previous line's
+    indentation
+
+### Custom anchors
+
+Several custom anchor functions handle Erlang-specific alignment:
+
+- `erlang-ts--anchor-matching-open` — matches closing delimiters to their
+  openers (`)` to `(`, `]` to `[`, `}` to `{`)
+- `erlang-ts--anchor-after-open-delim` — returns position after the first
+  `(`, `[`, or `{` in the parent node
+- `erlang-ts--anchor-args` — smart function argument alignment that detects
+  Okeefe style (paren at end of line)
+- `erlang-ts--anchor-after-open-brace` — `{`-specific for records/maps
+  (skips `(` which comes first in `-record(name, {...})`)
+- `erlang-ts--anchor-after-open-bracket` — `[`-specific for export/import
+  attributes (skips `(` in `-export([...])`)
+- `erlang-ts--grand-parent-bol` — like `parent-bol` but one level up in the
+  tree
+
+### Custom matchers
+
+- `erlang-ts--match-clause-body-in` — matches clause_body children inside a
+  specific grandparent type (e.g., `fun_clause`, `receive_after`)
+- `erlang-ts--match-inline-clause-body` — matches clause_body when the clause
+  starts on the same line as the enclosing block keyword (for double-indent)
+- `erlang-ts--match-triple-comment` / `erlang-ts--match-single-comment` —
+  detect `%%%` and `%` comments for special indentation
+
+### Known limitations
+
+The main gap is **continuation lines** — cases where a multi-line expression
+wraps and the tree-sitter node at BOL is deep inside a node that started on
+the previous line.  The `treesit-simple-indent-rules` system doesn't have a
+native concept of "this line is a continuation," and erlang-mode uses
+heuristics to detect this.
+
+The **ERROR node handling** is also basic — when code is incomplete during
+editing, tree-sitter produces ERROR nodes and the indentation falls back to
+`parent-bol + erlang-indent-level`, which doesn't always produce the right
+result.  Improving this would require context-aware ERROR handling (detecting
+whether the ERROR is inside a case, function, etc.).
+
+## Embedded markdown in doc attributes
+
+The `-doc` and `-moduledoc` attributes contain markdown text.  On Emacs 30+,
+`erlang-ts-mode` uses tree-sitter language injection to highlight markdown
+syntax inside these strings.
+
+The implementation uses `:local t` range settings, which creates local
+(per-range) parsers managed internally by treesit.  This means:
+
+- Font-lock works correctly (bold, italic, code spans, links are highlighted)
+- The markdown-inline parsers don't appear in `(treesit-parser-list)` (only
+  global parsers are listed)
+- `erlang-ts--language-at-point` may not detect the local parsers (this is a
+  treesit limitation, not a bug)
+
+The feature is gated on `(>= emacs-major-version 30)` because the `:local`
+keyword in `treesit-range-rules` was added in Emacs 30.
+
+## Tips for development
+
+### Reloading code
+
+The lazy initialization pattern means that `eval-buffer` on `erlang-ts.el`
+won't update font-lock rules or indent rules in existing buffers (they're
+cached in buffer-local variables set during mode setup).  To fully reload:
+
+1. `M-x eval-buffer` on `erlang-ts.el`
+2. Reset cached values: `(setq erlang-ts-font-lock-rules nil)`
+3. Re-enable the mode: `M-x erlang-ts-mode`
+
+Or simply close and reopen the Erlang buffer.
+
+### Adding new indentation rules
+
+- Use `M-x treesit-explore-mode` to inspect the AST at point
+- Set `treesit--indent-verbose` to `t` to see which rules match during
+  indentation
+- Order matters: more specific rules must come before general ones
+- The `parent-bol` anchor resolves to the first non-whitespace column on the
+  parent node's starting line
+- `parent-is` uses **regexp matching**, so `"binary"` matches both `binary`
+  and `binary_op_expr` — use `"^binary$"` for exact matches
+- Test new rules with `eldev test`
+
+### Running tests
+
+```
+eldev byte-compile --warnings-as-errors
+eldev test
+eldev lint
+```
+
+## Sources of inspiration
+
+- [neocaml](https://github.com/bbatsov/neocaml) — tree-sitter OCaml mode
+  (indentation architecture, lazy init, embedded markdown)
+- [clojure-ts-mode](https://github.com/clojure-emacs/clojure-ts-mode) —
+  embedded markdown in docstrings
+- [erlang-mode](https://github.com/erlang/otp/tree/master/lib/tools/emacs) —
+  the parent mode
+
+## References
+
+- [Parsing Program Source](https://www.gnu.org/software/emacs/manual/html_node/elisp/Parsing-Program-Source.html)
+- [Tree-sitter Major Modes](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tree_002dsitter-Major-Modes.html)
+- [Parser-based Indentation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Parser_002dbased-Indentation.html)
+- [WhatsApp/tree-sitter-erlang](https://github.com/WhatsApp/tree-sitter-erlang) — the Erlang tree-sitter grammar

--- a/erlang-ts.el
+++ b/erlang-ts.el
@@ -27,42 +27,23 @@
 
 ;;; Commentary:
 
-;; # Emacs Erlang mode using treesitter #
+;; `erlang-ts-mode' is a tree-sitter powered major mode for editing Erlang.
+;; It derives from `erlang-mode' and progressively replaces its features
+;; with tree-sitter based implementations.
 ;;
-;; Requires emacs-29 compiled with treesitter support.
+;; Features:
+;; - Tree-sitter based font-locking (4 levels)
+;; - Tree-sitter based indentation (experimental, opt-in)
+;; - Embedded markdown highlighting in doc attributes (Emacs 30+)
+;; - Imenu support for functions, macros, records, and types
+;; - Everything else inherited from erlang-mode
 ;;
-;; Uses tree-sitter for syntax-highlighting and indentation.
-;; Other features are inherited from erlang-mode.
+;; Install the tree-sitter grammar with:
+;;   M-x erlang-ts-install-grammar
 ;;
-;; # Install #
-;;
-;; Add to your .emacs file:
-;;
-;; ```
-;;  (add-to-list 'treesit-language-source-alist
-;;       '(erlang "https://github.com/WhatsApp/tree-sitter-erlang"))
-;;
-;;  (use-package erlang-ts
-;;      :mode ("\\.erl\\'" . erlang-ts-mode)
-;;      :defer 't)
-;; ```
-;; Install/compile erlang treesitter support (first time or upgrade grammer):
-;;
-;; ```
-;;   M-x treesit-install-language-grammar
-;;   Language: erlang
-;; ```
-;;
-;;; Code:
+;; See the README for full documentation.
 
-;; Introduction:
-;; ------------
-;; Handles font-locking and indentation for erlang-mode using tree-sitter.
-;;
-;; Devs See:
-;;    M-x treesit-explore-mode
-;; and also
-;;   (info "(elisp) Parsing Program Source")
+;;; Code:
 
 (require 'treesit)
 (require 'erlang)


### PR DESCRIPTION
I've extended the docs to make the project more approachable for both end users and potential contributors. I drew on the existing documentation for clojure-ts-mode and neocaml and opted for a similar documentation structure for erlang-ts.

The main changes are the following:

- README overhaul: features list, font-lock levels, font-lock customization (selecting features, customizing faces), LSP/Eglot setup, relationship with erlang-mode, migration guide
- `doc/DESIGN.md`: architecture, lazy initialization, font-lock and indentation rule design, embedded markdown approach, development tips
- `erlang-ts.el` commentary: concise feature summary replacing verbose install instructions